### PR TITLE
implemented reanimated for playback styling

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
   },
   "dependencies": {
-    "@dudigital/react-native-zoomable-view": "^1.1.3",
     "@react-native-async-storage/async-storage": "^1.15.17",
     "@react-native-community/slider": "^4.2.0",
     "@react-navigation/bottom-tabs": "^6.1.0",
@@ -42,7 +41,6 @@
     "react-native-reanimated": "^2.3.2",
     "react-native-safe-area-context": "^3.3.2",
     "react-native-screens": "^3.10.2",
-    "react-native-smooth-picker": "^1.1.5",
     "react-native-smooth-slider": "^1.3.4",
     "react-native-sound-player": "0.11.1",
     "react-native-svg": "^12.1.1",

--- a/src/components/ArtistListComponent/ArtistListComponent.tsx
+++ b/src/components/ArtistListComponent/ArtistListComponent.tsx
@@ -1,6 +1,6 @@
 import { useNavigation } from "@react-navigation/native";
 import React, { useEffect } from "react";
-import { FlatList, Text, TouchableOpacity, View } from "react-native";
+import { FlatList, Text, TouchableOpacity, useColorScheme, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import TrackPlayer from "react-native-track-player";
 import { useDispatch } from "react-redux";
@@ -21,6 +21,9 @@ const ArtistList = () => {
     const autoPlay = useTypedSelector(state => state.Options.autoPlayOnReload);
     const navigation = useNavigation();
     const dispatch = useDispatch();
+    const options = useTypedSelector(state => state.Options);
+    const systemColorScheme = useColorScheme();
+    const isDarkMode = options.overrideSystemAppearance ? options.isDarkmode : systemColorScheme === 'dark';
     const { artists } = albumsState;
 
     const selectArtistFromList = (artistName: string, pressedTitle: string) => {
@@ -71,7 +74,7 @@ const ArtistList = () => {
                                         subItemFlatlist={(
                                             <FlatList
                                                 data={item.songs}
-                                                renderItem={({ item }: { item: Song }) => (<SongCard song={item} />)}
+                                                renderItem={({ item }: { item: Song }) => (<SongCard song={item} colorScheme={isDarkMode ? 'dark' : 'light'} />)}
                                                 keyExtractor={(item, index) => `${getSongId(item)}-${index}`}
                                                 extraData={item}
                                             />

--- a/src/components/Cards/SongCard/SongCard.style.ts
+++ b/src/components/Cards/SongCard/SongCard.style.ts
@@ -1,5 +1,8 @@
 import { StyleSheet } from "react-native";
 
+export const SongCardHeight = 85;
+export const MARGIN = 5;
+
 const styles = StyleSheet.create({
     indexNumber: {
         fontSize: 18
@@ -17,8 +20,11 @@ const styles = StyleSheet.create({
         justifyContent: 'space-between',
         alignItems: 'center',
         padding: 15,
-        height: 85,
-        alignSelf: 'stretch'
+        height: SongCardHeight,
+        alignSelf: 'center',
+        borderWidth: 1,
+        borderRadius: 8,
+        marginVertical: MARGIN
     },
     infoView: {
         flexDirection: 'column',

--- a/src/constant/Color.ts
+++ b/src/constant/Color.ts
@@ -9,7 +9,16 @@ const color = {
     FLORAL_WHITE: 'floralwhite'
 };
 
-export const colorScheme = {
+interface ColorScheme {
+    [key: string]: {
+        background: string;
+        outline: string;
+        content: string;
+        contentBackground: string;
+    }
+}
+
+export const colorScheme: ColorScheme = {
     dark: {
         background: '#190a10',
         outline: 'darkred',

--- a/src/screens/PlaybackScreen/Playback.style.ts
+++ b/src/screens/PlaybackScreen/Playback.style.ts
@@ -7,12 +7,11 @@ const styles = StyleSheet.create({
         justifyContent: 'space-evenly'
     },
     scrollView: {
-        height: 300,
+        height: '70%',
         alignSelf: 'center'
     },
-    songCardView: {
-        borderWidth: 1,
-        borderRadius: 10
+    itemSeparator: {
+        height: 1
     }
 });
 

--- a/src/screens/Playlist/Playlist.tsx
+++ b/src/screens/Playlist/Playlist.tsx
@@ -1,7 +1,7 @@
 import { createMaterialTopTabNavigator } from "@react-navigation/material-top-tabs";
 import { useNavigation } from "@react-navigation/native";
 import React from "react";
-import { Button, FlatList, Pressable, Switch, Text, View } from "react-native";
+import { Button, FlatList, Pressable, Switch, Text, useColorScheme, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useDispatch } from "react-redux";
 import ModalDropdown from 'react-native-modal-dropdown';
@@ -28,10 +28,17 @@ const Playlist = () => {
     const playerOptions = useTypedSelector(state => state.Playlist.playbackOptions);
     const dispatch = useDispatch();
     const navigation = useNavigation();
+    const options = useTypedSelector(state => state.Options);
+    const systemColorScheme = useColorScheme();
+    const isDarkMode = options.overrideSystemAppearance ? options.isDarkmode : systemColorScheme === 'dark';
 
 
     const songView = ({ item }: { item: Song }) => (
-        <SongCard song={item} onWeightChange={value => dispatch(setSongWeight(getSongId(item), value))}/>
+        <SongCard
+            song={item}
+            onWeightChange={value => dispatch(setSongWeight(getSongId(item), value))}
+            colorScheme={isDarkMode ? 'dark' : 'light'}
+        />
     );
 
     const albumView = ({ item }: { item: Album }) => (
@@ -132,7 +139,11 @@ const Playlist = () => {
     );
 
     const individualSongView = ({ item }: { item: Song }) => (
-        <SongCard song={item} onWeightChange={newWeight => dispatch(setSongWeight(getSongId(item), newWeight))} />
+        <SongCard
+            song={item}
+            onWeightChange={newWeight => dispatch(setSongWeight(getSongId(item), newWeight))}
+            colorScheme={isDarkMode ? 'dark' : 'light'}
+        />
     );
 
     const songsView = () => (


### PR DESCRIPTION
# Problem

The current logic for styling the playback list is rather clunky

# Solution

## Reanimated Playback Playlist

To do this, React Native Reanimated was implemented

### Testing How-To

Ensure that there are enough songs to scroll through in the playback playlist, and go to the playback screen.  From here you should be able to scroll and view that the animation is much smoother


## Further Code Changes

Additionally improved color scheming (typed the color scheme as part of this), and removed zoomable view and smooth picker


## Notes

With the flatlist, it is unable to handle large lists smoothly, so large lists will need to be adjusted in the future.
