### PR TITLE
Make Song Repetition Configurable during Randomization

### DIFF
--- a/src/components/ArtistListComponent/ArtistListComponent.tsx
+++ b/src/components/ArtistListComponent/ArtistListComponent.tsx
@@ -1,6 +1,6 @@
 import { useNavigation } from "@react-navigation/native";
 import React, { useEffect } from "react";
-import { FlatList, Text, TouchableOpacity, useColorScheme, View } from "react-native";
+import { FlatList, useColorScheme, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import TrackPlayer from "react-native-track-player";
 import { useDispatch } from "react-redux";
@@ -8,9 +8,9 @@ import { Album, Artist, Song } from "../../models/MusicModel";
 import { selectArtist } from "../../state/actions/Albums";
 import { setAlbumAsCurrentPlaylist, setCurrentPlayArray, shuffleCurrentPlaylist } from "../../state/actions/Playlist";
 import { useTypedSelector } from "../../state/reducers";
-import { PlaybackMode, RandomizationType } from "../../state/reducers/Playlist";
+import { PlaybackMode } from "../../state/reducers/Playlist";
 import { convertSongListToTracks, getAlbumId, getPlayArray, getSongId } from "../../utils/musicUtils";
-import { getRandomizedNextSong } from "../../utils/PlaylistRandomization";
+import { getRandomizedSongs } from "../../utils/PlaylistRandomization";
 import AlbumCard from "../Cards/AlbumCard/AlbumCard";
 import ArtistCard from "../Cards/ArtistCard/ArtistCard";
 import ComponentDropDown from "../Cards/ComponentDropDown/ComponentDropDown";
@@ -39,13 +39,12 @@ const ArtistList = () => {
             TrackPlayer.reset().then(() => {
                 if (navigation.isFocused() && currentPlaylist) {
                     if (playbackOptions.mode === PlaybackMode.RANDOMIZE) {
-                        const initialSongs: Song[] = [];
-                        for (let i = 0; i < options.randomizationForwardBuffer; i++) {
-                            initialSongs.push(getRandomizedNextSong(
-                                currentPlaylist,
-                                playbackOptions.randomizeOptions.weighted
-                            ));
-                        }
+                        const initialSongs = getRandomizedSongs(
+                            currentPlaylist,
+                            options.randomizationForwardBuffer,
+                            playbackOptions.randomizeOptions.weighted,
+                            options.randomizationShouldNotRepeatSongs
+                        );
                         dispatch(setCurrentPlayArray(initialSongs));
                         TrackPlayer.add(convertSongListToTracks(initialSongs))
                             .then(() => {
@@ -97,19 +96,19 @@ const ArtistList = () => {
                                                         await TrackPlayer.add(convertSongListToTracks(currentPlaylist.playArray));
                                                         break;
                                                     case PlaybackMode.RANDOMIZE:
-                                                        const initialSongs: Song[] = [];
-                                                        for (let i = 0; i < options.randomizationForwardBuffer; i++) {
-                                                            initialSongs.push(getRandomizedNextSong(
-                                                                currentPlaylist,
-                                                                playbackOptions.randomizeOptions.weighted
-                                                            ));
-                                                        }
+                                                        const initialSongs = getRandomizedSongs(
+                                                            currentPlaylist,
+                                                            options.randomizationForwardBuffer,
+                                                            playbackOptions.randomizeOptions.weighted,
+                                                            options.randomizationShouldNotRepeatSongs
+                                                        );
                                                         dispatch(setCurrentPlayArray(initialSongs));
                                                         await TrackPlayer.add(convertSongListToTracks(initialSongs));
                                                         break;
                                                     default:
                                                         return;
-                                                }                                                TrackPlayer.play();
+                                                }
+                                                TrackPlayer.play();
                                                 // @ts-ignore
                                                 navigation.navigate('Playback')
                                             }

--- a/src/components/Cards/PlaylistCard/PlaylistCard.tsx
+++ b/src/components/Cards/PlaylistCard/PlaylistCard.tsx
@@ -14,8 +14,7 @@ import ComponentDropDown from "../ComponentDropDown/ComponentDropDown";
 import styles from "./PlaylistCard.style";
 import { useTypedSelector } from "../../../state/reducers";
 import { PlaybackMode } from "../../../state/reducers/Playlist";
-import { getRandomizedNextSong } from "../../../utils/PlaylistRandomization";
-import { spreadOrderedAlbumShuffle } from "../../../utils/OrderedAlbumShuffle";
+import { getRandomizedSongs } from "../../../utils/PlaylistRandomization";
 
 interface PlaylistCardProps {
     playlist: Playlist,
@@ -107,13 +106,12 @@ const PlaylistCard = (props: PlaylistCardProps) => {
                 }
                 break;
             case PlaybackMode.RANDOMIZE:
-                const initialSongs: Song[] = [];
-                for (let i = 0; i < options.randomizationForwardBuffer; i++) {
-                    initialSongs.push(getRandomizedNextSong(
-                        playlist,
-                        playbackOptions.randomizeOptions.weighted
-                    ));
-                }
+                const initialSongs = getRandomizedSongs(
+                    playlist,
+                    options.randomizationForwardBuffer,
+                    playbackOptions.randomizeOptions.weighted,
+                    options.randomizationShouldNotRepeatSongs
+                );
                 dispatch(setCurrentPlayArray(initialSongs));
                 await TrackPlayer.add(convertSongListToTracks(initialSongs));
                 break;

--- a/src/screens/Playlist/Playlist.tsx
+++ b/src/screens/Playlist/Playlist.tsx
@@ -16,8 +16,7 @@ import { OrderedType, PlaybackMode, RandomizationType } from "../../state/reduce
 import { convertSongListToTracks, getAlbumId, getPlayArray, getSongId } from "../../utils/musicUtils";
 import styles from "./Playlist.style";
 import TrackPlayer from "react-native-track-player";
-import { getRandomizedNextSong } from "../../utils/PlaylistRandomization";
-import { spreadOrderedAlbumShuffle } from "../../utils/OrderedAlbumShuffle";
+import { getRandomizedSongs } from "../../utils/PlaylistRandomization";
 
     const playbackModeOptions: PlaybackMode[] = [PlaybackMode.NORMAL, PlaybackMode.SHUFFLE, PlaybackMode.RANDOMIZE];
     const orderedTypeOptions: OrderedType[] = [OrderedType.NONE, OrderedType.SPREAD, OrderedType.RANDOM];
@@ -99,13 +98,12 @@ const Playlist = () => {
                     await TrackPlayer.add(convertSongListToTracks(currentPlaylist.playArray));
                     break;
                 case PlaybackMode.RANDOMIZE:
-                    const initialSongs: Song[] = [];
-                    for (let i = 0; i < options.randomizationForwardBuffer; i++) {
-                        initialSongs.push(getRandomizedNextSong(
-                            currentPlaylist,
-                            playbackOptions.randomizeOptions.weighted
-                        ));
-                    }
+                    const initialSongs = getRandomizedSongs(
+                        currentPlaylist,
+                        options.randomizationForwardBuffer,
+                        playbackOptions.randomizeOptions.weighted,
+                        options.randomizationShouldNotRepeatSongs
+                    );
                     dispatch(setCurrentPlayArray(initialSongs));
                     await TrackPlayer.add(convertSongListToTracks(initialSongs));
                     break;

--- a/src/state/reducers/Options.ts
+++ b/src/state/reducers/Options.ts
@@ -11,6 +11,7 @@ interface OptionsState {
     autoPlayOnReload: boolean;
     randomizationForwardBuffer: number;
     randomizationBackwardBuffer: number;
+    randomizationShouldNotRepeatSongs: boolean;
 };
 
 const initialState: OptionsState = {
@@ -18,7 +19,8 @@ const initialState: OptionsState = {
     isDarkmode: false,
     autoPlayOnReload: false,
     randomizationForwardBuffer: 10,
-    randomizationBackwardBuffer: 25
+    randomizationBackwardBuffer: 25,
+    randomizationShouldNotRepeatSongs: true
 };
 
 export const Options = (state = initialState, action: Actions): OptionsState => {

--- a/src/utils/PlaylistRandomization.ts
+++ b/src/utils/PlaylistRandomization.ts
@@ -1,10 +1,36 @@
+import _ from "lodash";
 import { Playlist, Song } from "../models/MusicModel.d";
 
-export const getRandomizedNextSong = (playlist: Playlist, weighted = false): Song => {
+export const getRandomizedSongs = (playlist: Playlist, numberToGet: number, weighted: boolean, noSkip: boolean): Song[] => {
+    const songsToAdd: Song[] = [];
+    songsToAdd.push(getRandomizedNextSong(playlist, weighted));
+    for (let i = 1; i < numberToGet; i++) {
+        let nextSong: Song;
+        if (noSkip) {
+            nextSong = getRandomizedNextSong(
+                playlist,
+                weighted,
+                songsToAdd[i - 1]
+            );
+        } else {
+            nextSong = getRandomizedNextSong(
+                playlist,
+                weighted
+            );
+        }
+        songsToAdd.push(nextSong);
+    }
+    return songsToAdd;
+}
+
+export const getRandomizedNextSong = (playlist: Playlist, weighted: boolean, previousSong?: Song): Song => {
     const availableSongs = weighted ? getWeightedAvailableSongs(playlist) : getAvailableSongs(playlist);
 
     const numberOfSongs = availableSongs.length;
-    const randomIndex = Math.floor(Math.random() * numberOfSongs);
+    let randomIndex = Math.floor(Math.random() * numberOfSongs);
+    while (_.isEqual(availableSongs[randomIndex], previousSong)) {
+        randomIndex = Math.floor(Math.random() * numberOfSongs);
+    }
     return availableSongs[randomIndex];
 };
 


### PR DESCRIPTION
# Problem

When the playback is in randomize mode, there is a chance that the same song can appear a second time in a row.  We want to make this configurable.

# Solution

## Configurable Repetition closes #30 

Made so that when a song is chosen, if the no repeat option is true, the app will choose a new song if the chosen next song is the same as the last one in the array of songs.

### Testing How-To

In a playlist, increase the weight of a song to an extreme value, and play with weighted randomization on.  That song should always have at least one different song between every occurrence of the extremely weighted song.