### PR TITLE
Separate Playing and Viewing Playlists

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,6 +25,10 @@ module.exports = {
         'curly': 'error',
         'dot-notation': 'error',
         'sort-imports': 'warn',
+        'no-duplicate-imports': 'error',
+        'no-unused-vars': 'warn',
+        'no-unused-expressions': 'warn',
+        'no-unused-imports': 'warn',
         'jsx-quotes': ['error', 'prefer-double'],
         'quotes': ['error', 'single', { "allowTemplateLiterals": true }]
       },

--- a/src/components/ArtistListComponent/ArtistListComponent.tsx
+++ b/src/components/ArtistListComponent/ArtistListComponent.tsx
@@ -6,7 +6,7 @@ import TrackPlayer from 'react-native-track-player';
 import { useDispatch } from 'react-redux';
 import { Album, Artist, Song } from '../../models/MusicModel';
 import { selectArtist } from '../../state/actions/Albums';
-import { setAlbumAsCurrentPlaylist, setCurrentPlayArray, shuffleCurrentPlaylist } from '../../state/actions/Playlist';
+import { setAlbumAsPlayingPlaylist, setViewingPlayArray, shuffleViewingPlaylist } from '../../state/actions/Playlist';
 import { useTypedSelector } from '../../state/reducers';
 import { PlaybackMode } from '../../state/reducers/Playlist';
 import {
@@ -24,7 +24,7 @@ import styles from './ArtistListComponent.style';
 
 const ArtistList = () => {
     const albumsState = useTypedSelector(state => state.Albums);
-    const { currentPlaylist, playbackOptions } = useTypedSelector(state => state.Playlist);
+    const { viewingPlaylist: currentPlaylist, playbackOptions } = useTypedSelector(state => state.Playlist);
     const { artists } = albumsState;
     const autoPlay = useTypedSelector(state => state.Options.playbackAutoPlayOnReload);
     const navigation = useNavigation();
@@ -63,7 +63,7 @@ const ArtistList = () => {
                             playbackOptions.randomizeOptions.weighted,
                             options.randomizationShouldNotRepeatSongs
                         );
-                        dispatch(setCurrentPlayArray(initialSongs));
+                        dispatch(setViewingPlayArray(initialSongs));
                         TrackPlayer.add(convertSongListToTracks(initialSongs))
                             .then(() => {
                                 TrackPlayer.play();
@@ -98,18 +98,18 @@ const ArtistList = () => {
                                 renderItem={({ item }: { item: Album }) => (
                                     <ComponentDropDown
                                         mainItemCard={(<AlbumCard album={item} onPlay={async () => {
-                                            dispatch(setAlbumAsCurrentPlaylist(item));
+                                            dispatch(setAlbumAsPlayingPlaylist(item));
                                             await TrackPlayer.reset();
                                             await TrackPlayer.removeUpcomingTracks();
                                             if (currentPlaylist) {
                                                 switch (playbackOptions.mode) {
                                                     case PlaybackMode.NORMAL:
                                                         const playArray = getPlayArray(currentPlaylist);
-                                                        dispatch(setCurrentPlayArray(playArray));
+                                                        dispatch(setViewingPlayArray(playArray));
                                                         break;
                                                     case PlaybackMode.SHUFFLE:
-                                                        dispatch(setCurrentPlayArray(getPlayArray(currentPlaylist)));
-                                                        dispatch(shuffleCurrentPlaylist());
+                                                        dispatch(setViewingPlayArray(getPlayArray(currentPlaylist)));
+                                                        dispatch(shuffleViewingPlaylist());
                                                         break;
                                                     case PlaybackMode.RANDOMIZE:
                                                         const initialSongs = getRandomizedSongs(
@@ -118,7 +118,7 @@ const ArtistList = () => {
                                                             playbackOptions.randomizeOptions.weighted,
                                                             options.randomizationShouldNotRepeatSongs
                                                         );
-                                                        dispatch(setCurrentPlayArray(initialSongs));
+                                                        dispatch(setViewingPlayArray(initialSongs));
                                                         break;
                                                     default:
                                                         return;

--- a/src/state/actions/Playlist.ts
+++ b/src/state/actions/Playlist.ts
@@ -9,12 +9,14 @@ export const GENERATE_PLAYLIST = 'PLAYLIST/GENERATE_PLAYLIST';
 export const EDIT_PLAYLIST = 'PLAYLIST/EDIT';
 
 export const SET_CURRENT_PLAYLIST = 'PLAYLIST/SET_CURRENT';
-export const SET_ALBUM_AS_PLAYLIST = 'PLAYLIST/SET_ALBUM_AS';
+export const SET_ALBUM_TO_PLAYLIST = 'PLAYLIST/SET_ALBUM_AS';
+export const SET_CURRENT_AS_PLAYING = 'PLAYLIST/SET_CURRENT_AS_PLAYING';
 
 export const SET_ALBUM_ORDERED = 'PLAYLIST/SET_ALBUM_ORDERED';
 export const SET_SONG_WEIGHT = 'PLAYLIST/SET_SONG_WEIGHT';
-export const SHUFFLE_CURRENT_PLAYLIST = 'PLAYLIST/SHUFFLE_CURRENT';
-export const SET_CURRENT_PLAY_ARRAY = 'PLAYLIST/SET_PLAY_ARRAY';
+export const SHUFFLE_VIEWING_PLAYLIST = 'PLAYLIST/SHUFFLE_VIEWING';
+export const SHUFFLE_PLAYING_PLAYLIST = 'PLAYLIST/SHUFFLE_PLAYING';
+export const SET_VIEWING_PLAY_ARRAY = 'PLAYLIST/SET_VIEWING_PLAY_ARRAY';
 export const SET_RANDOM_NEXT_SONG = 'PLAYLIST/SET_RANDOM_NEXT_SONG';
 export const REMOVE_OLDEST_RANDOM_SONG = 'PLAYLIST/REMOVE_OLDEST_RANDOM';
 
@@ -65,9 +67,13 @@ export const setCurrentPlaylist = (playlist: Playlist) => ({
     payload: playlist
 } as const);
 
-export const setAlbumAsCurrentPlaylist = (album: Album) => ({
-    type: SET_ALBUM_AS_PLAYLIST,
+export const setAlbumAsPlayingPlaylist = (album: Album) => ({
+    type: SET_ALBUM_TO_PLAYLIST,
     payload: album
+} as const);
+
+export const setCurrentPlaylistAsPlaying = () => ({
+    type: SET_CURRENT_AS_PLAYING
 } as const);
 
 export const setAlbumOrdered = (albumId: string, ordered: boolean, playlistName?: string) => ({
@@ -80,12 +86,16 @@ export const setSongWeight = (songId: string, weight: number, playlistName?: str
     payload: { playlistName, songId, weight }
 } as const);
 
-export const shuffleCurrentPlaylist = () => ({
-    type: SHUFFLE_CURRENT_PLAYLIST
+export const shuffleViewingPlaylist = () => ({
+    type: SHUFFLE_VIEWING_PLAYLIST
 } as const);
 
-export const setCurrentPlayArray = (songs: Song[]) => ({
-    type: SET_CURRENT_PLAY_ARRAY,
+export const shufflePlayingPlaylist = () => ({
+    type: SHUFFLE_PLAYING_PLAYLIST
+} as const);
+
+export const setViewingPlayArray = (songs: Song[]) => ({
+    type: SET_VIEWING_PLAY_ARRAY,
     payload: songs
 } as const);
 
@@ -151,11 +161,13 @@ export type Actions =
     | ReturnType<typeof generatePlaylist>
     | ReturnType<typeof editPlaylist>
     | ReturnType<typeof setCurrentPlaylist>
-    | ReturnType<typeof setAlbumAsCurrentPlaylist>
+    | ReturnType<typeof setAlbumAsPlayingPlaylist>
+    | ReturnType<typeof setCurrentPlaylistAsPlaying>
     | ReturnType<typeof setAlbumOrdered>
     | ReturnType<typeof setSongWeight>
-    | ReturnType<typeof shuffleCurrentPlaylist>
-    | ReturnType<typeof setCurrentPlayArray>
+    | ReturnType<typeof shuffleViewingPlaylist>
+    | ReturnType<typeof shufflePlayingPlaylist>
+    | ReturnType<typeof setViewingPlayArray>
     | ReturnType<typeof setRandomNextSongs>
     | ReturnType<typeof removeOldestRandomSongs>
     | ReturnType<typeof setSavedPlaylists>

--- a/src/utils/PlaylistShuffle.ts
+++ b/src/utils/PlaylistShuffle.ts
@@ -1,4 +1,5 @@
-import { Album, Song } from '../models/MusicModel';
+import { Album, Playlist, Song } from '../models/MusicModel';
+import { ShuffleType } from '../state/reducers/Playlist';
 import { getSongId } from './musicUtils';
 
 interface songIdPos {
@@ -106,4 +107,18 @@ export const standardShuffle = (albums: Album[], individualSongs: Song[]): Song[
     });
 
     return songListToPlaylist(songList, unorderedPlaylist); 
+};
+
+export const getShuffledByType = (playlist: Playlist, type: ShuffleType): Song[] => {
+    switch (type) {
+        case ShuffleType.STANDARD:
+            return standardShuffle(playlist.albums, playlist.songs);
+        case ShuffleType.STANDARD_ORDERED:
+            // TODO implement random ordered shuffle
+            return [];
+        case ShuffleType.SPREAD_ORDERED:
+            return spreadOrderedAlbumShuffle(playlist.albums, playlist.songs);
+        default:
+            return playlist.playArray;
+    }
 };


### PR DESCRIPTION
# Problem

The user will likely want to view a playlist while already playing a playlist.  However, the app currently uses the same state for both viewing and playing playlists

# Solution

## Separate playing and viewing playlists closes #55 

The playlist state was adjusted to have playingPlaylist and viewingPlaylist fields

### Testing How-To

Have a playlist playing, and go to view a playlist.  After this, go back to the playback view, which should still have the currently playing songs in the list


## Notes

Also made changes to the lint options
