### PR TITLE
Edit Playlist Added Icons

### DIFF
--- a/src/screens/NewPlaylist/NewPlaylist.tsx
+++ b/src/screens/NewPlaylist/NewPlaylist.tsx
@@ -72,8 +72,8 @@ const NewPlaylist = () => {
         return true;
     };
 
-    const albumInPlaylist = (album: Album) => newPlaylist.albums.includes(album);
-    const songInPlaylist = (song: Song) => newPlaylist.individualSongs.includes(song);
+    const albumInPlaylist = (album: Album) => newPlaylist.albums.some(albm => getAlbumId(album) === getAlbumId(albm));
+    const songInPlaylist = (song: Song) => newPlaylist.individualSongs.some(sng => getSongId(song) === getSongId(sng));
     
     const availableSongView = ({ item }: { item: Song }) => (
         <SongCard


### PR DESCRIPTION
# Problem

When the user goes to edit a playlist, they have been suffering from looking at the available music and not knowing what music has already been added.  This is because the screen does a check on the equality of the albums/songs in the saved playlist against the albums/songs in the available.  This is an object comparison, and the saved playlist has different objects than the available music.

# Solution

## Albums and Songs not showing as added in edit

The object equality check  for if the item is in the playlist has been replaced with one that performs an ID check through the given arrays.

### Testing How-To

Having a playlist created, navigate to that playlist, and select the edit button.  From there, find an artist with music already in the playlist, and open the dropdowns to reveal
