### PR TITLE
App Cannot Play Album Standalone

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -24,6 +24,9 @@ import store, { persistor } from './src/state/store';
 import TrackPlayer, { Capability } from 'react-native-track-player';
 import { PersistGate } from 'redux-persist/integration/react';
 import HomeNavigator from './src/navigators/HomeNavigator';
+if (__DEV__) {
+    import('./ReactotronConfig').then(() => console.log('Reactotron Configured'));
+}
 
 const App = () => {
   const isDarkMode = useColorScheme() === 'dark';

--- a/ReactotronConfig.js
+++ b/ReactotronConfig.js
@@ -1,0 +1,12 @@
+import Reactotron, { asyncStorage } from 'reactotron-react-native';
+import { reactotronRedux } from 'reactotron-redux';
+import { AsyncStorage } from '@react-native-async-storage/async-storage';
+
+const reactotron = Reactotron
+    .configure() // controls connection & communication settings
+    .useReactNative() // add all built-in react native plugins
+    .use(reactotronRedux())
+    .use(asyncStorage())
+    .connect(); // let's connect!
+
+export default reactotron;

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -138,8 +138,8 @@ android {
         applicationId "com.musicapptoo"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 10
-        versionName "1.4.1"
+        versionCode 11
+        versionName "1.4.2"
         buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
 
         if (isNewArchitectureEnabled()) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,6 +75,8 @@
         "jetifier": "^2.0.0",
         "metro-react-native-babel-preset": "^0.72.1",
         "react-test-renderer": "18.1.0",
+        "reactotron-react-native": "^5.0.4",
+        "reactotron-redux": "^3.1.5",
         "typescript": "^4.4.4"
       }
     },
@@ -12677,6 +12679,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/microdiff": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/microdiff/-/microdiff-1.5.0.tgz",
+      "integrity": "sha512-Drq+/THMvDdzRYrK0oxJmOKiC24ayUV8ahrt8l3oRK51PWt6gdtrIGrlIH3pT/lFh1z93FbAcidtsHcWbnRz8Q==",
+      "dev": true
+    },
     "node_modules/micromatch": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
@@ -12745,6 +12753,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true
     },
     "node_modules/mixin-deep": {
       "version": "1.3.2",
@@ -14333,6 +14347,47 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
       "dev": true
+    },
+    "node_modules/reactotron-core-client": {
+      "version": "2.9.9",
+      "resolved": "https://registry.npmjs.org/reactotron-core-client/-/reactotron-core-client-2.9.9.tgz",
+      "integrity": "sha512-caI6ZWpfV/gNeCBhm6alxuCpOxYEFxg9FsgVaOXJWZeKjK2egjxkXcUEFWeS3b9mC6Kwi7Wuu79zfeGtkbdAYw==",
+      "dev": true,
+      "dependencies": {
+        "reactotron-core-contract": "0.3.2"
+      }
+    },
+    "node_modules/reactotron-core-contract": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/reactotron-core-contract/-/reactotron-core-contract-0.3.2.tgz",
+      "integrity": "sha512-39ZNLfxxV7WEOszekIRg56F6VFZrQk7+Lei+8MccNESX3VbQzs1uex/GNesxk6CMTS6ytwqYIBAgLyc9WX/PaA==",
+      "dev": true
+    },
+    "node_modules/reactotron-react-native": {
+      "version": "5.1.18",
+      "resolved": "https://registry.npmjs.org/reactotron-react-native/-/reactotron-react-native-5.1.18.tgz",
+      "integrity": "sha512-Nyb/w7tRQICtfvjAJSN6Q/3aRO8L6eTfEcWpDR/atUyoINkyzducMx6yXA+sz1mazxivY16N3VPkmQ1XohQAcg==",
+      "dev": true,
+      "dependencies": {
+        "mitt": "^3.0.1",
+        "reactotron-core-client": "2.9.9"
+      },
+      "peerDependencies": {
+        "react-native": ">=0.40.0"
+      }
+    },
+    "node_modules/reactotron-redux": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/reactotron-redux/-/reactotron-redux-3.2.1.tgz",
+      "integrity": "sha512-WxMVz1zBlzWplS3HJU1kDH1LBaTE71i/mMdyRTZZrAQq33+SKd7hva03pMbd6UJFaQeSCvey26a2SSWp5CLsWg==",
+      "dev": true,
+      "dependencies": {
+        "microdiff": "^1.5.0"
+      },
+      "peerDependencies": {
+        "reactotron-core-client": "*",
+        "redux": ">=4.0.0"
+      }
     },
     "node_modules/read-pkg": {
       "version": "5.2.0",
@@ -26400,6 +26455,12 @@
         }
       }
     },
+    "microdiff": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/microdiff/-/microdiff-1.5.0.tgz",
+      "integrity": "sha512-Drq+/THMvDdzRYrK0oxJmOKiC24ayUV8ahrt8l3oRK51PWt6gdtrIGrlIH3pT/lFh1z93FbAcidtsHcWbnRz8Q==",
+      "dev": true
+    },
     "micromatch": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
@@ -26444,6 +26505,12 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
+    },
+    "mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true
     },
     "mixin-deep": {
       "version": "1.3.2",
@@ -27603,6 +27670,40 @@
           "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
           "dev": true
         }
+      }
+    },
+    "reactotron-core-client": {
+      "version": "2.9.9",
+      "resolved": "https://registry.npmjs.org/reactotron-core-client/-/reactotron-core-client-2.9.9.tgz",
+      "integrity": "sha512-caI6ZWpfV/gNeCBhm6alxuCpOxYEFxg9FsgVaOXJWZeKjK2egjxkXcUEFWeS3b9mC6Kwi7Wuu79zfeGtkbdAYw==",
+      "dev": true,
+      "requires": {
+        "reactotron-core-contract": "0.3.2"
+      }
+    },
+    "reactotron-core-contract": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/reactotron-core-contract/-/reactotron-core-contract-0.3.2.tgz",
+      "integrity": "sha512-39ZNLfxxV7WEOszekIRg56F6VFZrQk7+Lei+8MccNESX3VbQzs1uex/GNesxk6CMTS6ytwqYIBAgLyc9WX/PaA==",
+      "dev": true
+    },
+    "reactotron-react-native": {
+      "version": "5.1.18",
+      "resolved": "https://registry.npmjs.org/reactotron-react-native/-/reactotron-react-native-5.1.18.tgz",
+      "integrity": "sha512-Nyb/w7tRQICtfvjAJSN6Q/3aRO8L6eTfEcWpDR/atUyoINkyzducMx6yXA+sz1mazxivY16N3VPkmQ1XohQAcg==",
+      "dev": true,
+      "requires": {
+        "mitt": "^3.0.1",
+        "reactotron-core-client": "2.9.9"
+      }
+    },
+    "reactotron-redux": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/reactotron-redux/-/reactotron-redux-3.2.1.tgz",
+      "integrity": "sha512-WxMVz1zBlzWplS3HJU1kDH1LBaTE71i/mMdyRTZZrAQq33+SKd7hva03pMbd6UJFaQeSCvey26a2SSWp5CLsWg==",
+      "dev": true,
+      "requires": {
+        "microdiff": "^1.5.0"
       }
     },
     "read-pkg": {

--- a/package.json
+++ b/package.json
@@ -77,6 +77,8 @@
     "jetifier": "^2.0.0",
     "metro-react-native-babel-preset": "^0.72.1",
     "react-test-renderer": "18.1.0",
+    "reactotron-react-native": "^5.0.4",
+    "reactotron-redux": "^3.1.5",
     "typescript": "^4.4.4"
   },
   "resolutions": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "MusicAppToo",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "private": true,
   "scripts": {
     "android": "react-native run-android",

--- a/src/components/ArtistListComponent/ArtistListComponent.tsx
+++ b/src/components/ArtistListComponent/ArtistListComponent.tsx
@@ -25,7 +25,7 @@ import { titleSort } from '../../utils/stringUtils';
 
 const ArtistList = () => {
     const albumsState = useTypedSelector(state => state.Albums);
-    const { viewingPlaylist: currentPlaylist, playbackOptions } = useTypedSelector(state => state.Playlist);
+    const { playingPlaylist: currentPlaylist, playbackOptions } = useTypedSelector(state => state.Playlist);
     const { artists } = albumsState;
     const autoPlay = useTypedSelector(state => state.Options.playbackAutoPlayOnReload);
     const navigation = useNavigation();
@@ -101,7 +101,6 @@ const ArtistList = () => {
                                 mainItemCard={(<AlbumCard album={item} onPlay={async () => {
                                     dispatch(setAlbumAsPlayingPlaylist(item));
                                     await TrackPlayer.reset();
-                                    await TrackPlayer.removeUpcomingTracks();
                                     if (currentPlaylist) {
                                         switch (playbackOptions.mode) {
                                             case PlaybackMode.NORMAL:

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -4,11 +4,13 @@ import { persistStore } from 'redux-persist';
 import createSagaMiddleware from 'redux-saga';
 import rootReducer from './reducers';
 import rootSaga from './sagas';
+import reactotron from '../../ReactotronConfig';
 
 const sagaMiddleware = createSagaMiddleware();
 
 const enhancer = composeWithDevTools(
     compose(applyMiddleware(sagaMiddleware)),
+    reactotron.createEnhancer()
 );
 
 const store = createStore(rootReducer, enhancer);


### PR DESCRIPTION
# Problem

When the user attempts to set an album to play, the app misbehaves and does not play the chosen album

# Solution

## App Cannot Play Album Standalone

It was found that the app, instead of setting the selected album to play, was instead setting the *viewing* playlist to play.  The artist list screen was rightfully setting the album to the playing playlist, but the screen was taking in the viewing playlist as a previous holdover from before the playing and viewing playlists were separated.

### Testing How-To

Ensure that the app is currently playing a playlist, or with a playlist loaded to play.  Returning to the home screen, choose another album to play


## Further Code Changes

`TrackPlayer.removeUpcomingTracks()` was removed from the add album to play logic as debugging has revealed its redundancy
Reactotron redux implementations added
Version updated and apk attached


## Other Additions

Reactotron dev packages added to dev dependencies
