### PR TITLE
Search and Fixes

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -2,6 +2,8 @@ module.exports = {
   bracketSpacing: false,
   bracketSameLine: true,
   singleQuote: true,
-  trailingComma: 'all',
+  trailingComma: 'none',
   arrowParens: 'avoid',
+  tabWidth: 4,
+  printWidth: 120
 };

--- a/android/app/_BUCK
+++ b/android/app/_BUCK
@@ -35,12 +35,12 @@ android_library(
 
 android_build_config(
     name = "build_config",
-    package = "com.musicapptoo",
+    package = "com.palkrom.musicapptoo",
 )
 
 android_resource(
     name = "res",
-    package = "com.musicapptoo",
+    package = "com.palkrom.musicapptoo",
     res = "src/main/res",
 )
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -135,11 +135,11 @@ android {
     compileSdkVersion rootProject.ext.compileSdkVersion
 
     defaultConfig {
-        applicationId "com.musicapptoo"
+        applicationId "com.palkrom.musicapptoo"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 11
-        versionName "1.4.2"
+        versionCode 12
+        versionName "1.4.3"
         buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
 
         if (isNewArchitectureEnabled()) {
@@ -147,7 +147,7 @@ android {
             externalNativeBuild {
                 cmake {
                     arguments "-DPROJECT_BUILD_DIR=$buildDir",
-                        "-DREACT_ANDROID_DIR=$rootDir/../node_modules/react-native/ReactAndroid",
+                        "-DREACT_ANDROID_DIR=$rootDir/../_modules/react-native/ReactAndroid",
                         "-DREACT_ANDROID_BUILD_DIR=$rootDir/../node_modules/react-native/ReactAndroid/build",
                         "-DNODE_MODULES_DIR=$rootDir/../node_modules",
                         "-DANDROID_STL=c++_shared"
@@ -220,6 +220,7 @@ android {
     buildTypes {
         debug {
             signingConfig signingConfigs.debug
+            applicationIdSuffix = ".debug"
         }
         release {
             // Caution! In production, you need to generate your own keystore file.

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -138,8 +138,8 @@ android {
         applicationId "com.palkrom.musicapptoo"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 12
-        versionName "1.4.3"
+        versionCode 13
+        versionName "1.4.4"
         buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
 
         if (isNewArchitectureEnabled()) {

--- a/android/app/src/debug/java/com/musicapptoo/ReactNativeFlipper.java
+++ b/android/app/src/debug/java/com/musicapptoo/ReactNativeFlipper.java
@@ -4,7 +4,7 @@
  * <p>This source code is licensed under the MIT license found in the LICENSE file in the root
  * directory of this source tree.
  */
-package com.musicapptoo;
+package com.palkrom.musicapptoo;
 
 import android.content.Context;
 import com.facebook.flipper.android.AndroidFlipperClient;

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.musicapptoo">
+  package="com.palkrom.musicapptoo">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />

--- a/android/app/src/main/java/com/palkrom/musicapptoo/MainActivity.java
+++ b/android/app/src/main/java/com/palkrom/musicapptoo/MainActivity.java
@@ -1,4 +1,4 @@
-package com.musicapptoo;
+package com.palkrom.musicapptoo;
 
 import com.facebook.react.ReactActivity;
 import com.facebook.react.ReactActivityDelegate;

--- a/android/app/src/main/java/com/palkrom/musicapptoo/MainApplication.java
+++ b/android/app/src/main/java/com/palkrom/musicapptoo/MainApplication.java
@@ -1,4 +1,4 @@
-package com.musicapptoo;
+package com.palkrom.musicapptoo;
 
 import android.app.Application;
 import android.content.Context;
@@ -9,7 +9,7 @@ import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
 import com.facebook.react.config.ReactFeatureFlags;
 import com.facebook.soloader.SoLoader;
-import com.musicapptoo.newarchitecture.MainApplicationReactNativeHost;
+import com.palkrom.musicapptoo.newarchitecture.MainApplicationReactNativeHost;
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 
@@ -82,7 +82,7 @@ public class MainApplication extends Application implements ReactApplication {
          We use reflection here to pick up the class that initializes Flipper,
         since Flipper library is not available in release mode
         */
-        Class<?> aClass = Class.forName("com.musicapptoo.ReactNativeFlipper");
+        Class<?> aClass = Class.forName("com.palkrom.musicapptoo.ReactNativeFlipper");
         aClass
             .getMethod("initializeFlipper", Context.class, ReactInstanceManager.class)
             .invoke(null, context, reactInstanceManager);

--- a/android/app/src/main/java/com/palkrom/musicapptoo/newarchitecture/MainApplicationReactNativeHost.java
+++ b/android/app/src/main/java/com/palkrom/musicapptoo/newarchitecture/MainApplicationReactNativeHost.java
@@ -1,4 +1,4 @@
-package com.musicapptoo.newarchitecture;
+package com.palkrom.musicapptoo.newarchitecture;
 
 import android.app.Application;
 import androidx.annotation.NonNull;
@@ -19,9 +19,9 @@ import com.facebook.react.fabric.CoreComponentsRegistry;
 import com.facebook.react.fabric.FabricJSIModuleProvider;
 import com.facebook.react.fabric.ReactNativeConfig;
 import com.facebook.react.uimanager.ViewManagerRegistry;
-import com.musicapptoo.BuildConfig;
-import com.musicapptoo.newarchitecture.components.MainComponentsRegistry;
-import com.musicapptoo.newarchitecture.modules.MainApplicationTurboModuleManagerDelegate;
+import com.palkrom.musicapptoo.BuildConfig;
+import com.palkrom.musicapptoo.newarchitecture.components.MainComponentsRegistry;
+import com.palkrom.musicapptoo.newarchitecture.modules.MainApplicationTurboModuleManagerDelegate;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/android/app/src/main/java/com/palkrom/musicapptoo/newarchitecture/components/MainComponentsRegistry.java
+++ b/android/app/src/main/java/com/palkrom/musicapptoo/newarchitecture/components/MainComponentsRegistry.java
@@ -1,4 +1,4 @@
-package com.musicapptoo.newarchitecture.components;
+package com.palkrom.musicapptoo.newarchitecture.components;
 
 import com.facebook.jni.HybridData;
 import com.facebook.proguard.annotations.DoNotStrip;

--- a/android/app/src/main/java/com/palkrom/musicapptoo/newarchitecture/modules/MainApplicationTurboModuleManagerDelegate.java
+++ b/android/app/src/main/java/com/palkrom/musicapptoo/newarchitecture/modules/MainApplicationTurboModuleManagerDelegate.java
@@ -1,4 +1,4 @@
-package com.musicapptoo.newarchitecture.modules;
+package com.palkrom.musicapptoo.newarchitecture.modules;
 
 import com.facebook.jni.HybridData;
 import com.facebook.react.ReactPackage;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "MusicAppToo",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "private": true,
   "scripts": {
     "android": "react-native run-android",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "MusicAppToo",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "private": true,
   "scripts": {
     "android": "react-native run-android",

--- a/src/components/ArtistListComponent/ArtistListComponent.tsx
+++ b/src/components/ArtistListComponent/ArtistListComponent.tsx
@@ -11,19 +11,20 @@ import {useTypedSelector} from '../../state/reducers';
 import {PlaybackMode} from '../../state/reducers/Playlist';
 import {convertSongListToTracks, getAlbumId, getPlayArray, getSongId} from '../../utils/musicUtils';
 import {getRandomizedSongs} from '../../utils/PlaylistRandomization';
-import AlbumCard from '../Cards/AlbumCard/AlbumCard';
-import ArtistCard from '../Cards/ArtistCard/ArtistCard';
-import ComponentDropDown from '../Cards/ComponentDropDown/ComponentDropDown';
+import ArtistCard, {getFoundColor as getArtistFound} from '../Cards/ArtistCard/ArtistCard';
+import AlbumCard, {getFoundColor as getAlbumFound} from '../Cards/AlbumCard/AlbumCard';
 import SongCard from '../Cards/SongCard/SongCard';
+import ComponentDropDown from '../Cards/ComponentDropDown/ComponentDropDown';
 import styles from './ArtistListComponent.style';
 import {titleSort} from '../../utils/stringUtils';
 
 interface ArtistListProps {
+    isFilteredSearch: boolean;
     searched: string;
 }
 
 const ArtistList = (props: ArtistListProps) => {
-    const {searched} = props;
+    const {searched, isFilteredSearch} = props;
     const albumsState = useTypedSelector(state => state.Albums);
     const {playingPlaylist: currentPlaylist, playbackOptions} = useTypedSelector(state => state.Playlist);
     const {artists} = albumsState;
@@ -35,7 +36,11 @@ const ArtistList = (props: ArtistListProps) => {
     const isDarkMode = options.generalOverrideSystemAppearance ? options.generalDarkmode : systemColorScheme === 'dark';
     const [startPlayback, setStartPlayback] = useState(false);
 
-    const sortedArtists = useMemo(() => [...artists].sort((a, b) => titleSort(a.artist, b.artist)), [artists]);
+    const sortedArtists = useMemo(() => {
+        const filtered =
+            searched && isFilteredSearch ? artists.filter(artist => getArtistFound(artist, searched)) : [...artists];
+        return filtered.sort((a, b) => titleSort(a.artist, b.artist));
+    }, [artists, isFilteredSearch]);
 
     useEffect(() => {
         if (navigation.isFocused() && currentPlaylist && startPlayback) {
@@ -84,7 +89,11 @@ const ArtistList = (props: ArtistListProps) => {
     }, []);
 
     const renderArtist = ({item}: {item: Artist}) => {
-        const sortedAlbums = [...item.albums].sort((a, b) => titleSort(a.albumName, b.albumName));
+        const filtered =
+            searched && isFilteredSearch
+                ? item.albums.filter(album => getAlbumFound(album, searched))
+                : [...item.albums];
+        const sortedAlbums = filtered.sort((a, b) => titleSort(a.albumName, b.albumName));
         return (
             <ComponentDropDown
                 mainItemCard={<ArtistCard artist={item} searched={searched || undefined} />}

--- a/src/components/ArtistListComponent/ArtistListComponent.tsx
+++ b/src/components/ArtistListComponent/ArtistListComponent.tsx
@@ -1,32 +1,32 @@
-import { useNavigation } from '@react-navigation/native';
-import React, { useEffect, useMemo, useState } from 'react';
-import { FlatList, useColorScheme, View } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import {useNavigation} from '@react-navigation/native';
+import React, {useEffect, useMemo, useState} from 'react';
+import {FlatList, useColorScheme, View} from 'react-native';
+import {SafeAreaView} from 'react-native-safe-area-context';
 import TrackPlayer from 'react-native-track-player';
-import { useDispatch } from 'react-redux';
-import { Album, Artist, Song } from '../../models/MusicModel';
-import { selectArtist } from '../../state/actions/Albums';
-import { setAlbumAsPlayingPlaylist, setViewingPlayArray, shuffleViewingPlaylist } from '../../state/actions/Playlist';
-import { useTypedSelector } from '../../state/reducers';
-import { PlaybackMode } from '../../state/reducers/Playlist';
-import {
-    convertSongListToTracks,
-    getAlbumId,
-    getPlayArray,
-    getSongId
-} from '../../utils/musicUtils';
-import { getRandomizedSongs } from '../../utils/PlaylistRandomization';
+import {useDispatch} from 'react-redux';
+import {Album, Artist, Song} from '../../models/MusicModel';
+import {selectArtist} from '../../state/actions/Albums';
+import {setAlbumAsPlayingPlaylist, setViewingPlayArray, shuffleViewingPlaylist} from '../../state/actions/Playlist';
+import {useTypedSelector} from '../../state/reducers';
+import {PlaybackMode} from '../../state/reducers/Playlist';
+import {convertSongListToTracks, getAlbumId, getPlayArray, getSongId} from '../../utils/musicUtils';
+import {getRandomizedSongs} from '../../utils/PlaylistRandomization';
 import AlbumCard from '../Cards/AlbumCard/AlbumCard';
 import ArtistCard from '../Cards/ArtistCard/ArtistCard';
 import ComponentDropDown from '../Cards/ComponentDropDown/ComponentDropDown';
 import SongCard from '../Cards/SongCard/SongCard';
 import styles from './ArtistListComponent.style';
-import { titleSort } from '../../utils/stringUtils';
+import {titleSort} from '../../utils/stringUtils';
 
-const ArtistList = () => {
+interface ArtistListProps {
+    searched: string;
+}
+
+const ArtistList = (props: ArtistListProps) => {
+    const {searched} = props;
     const albumsState = useTypedSelector(state => state.Albums);
-    const { playingPlaylist: currentPlaylist, playbackOptions } = useTypedSelector(state => state.Playlist);
-    const { artists } = albumsState;
+    const {playingPlaylist: currentPlaylist, playbackOptions} = useTypedSelector(state => state.Playlist);
+    const {artists} = albumsState;
     const autoPlay = useTypedSelector(state => state.Options.playbackAutoPlayOnReload);
     const navigation = useNavigation();
     const dispatch = useDispatch();
@@ -35,19 +35,16 @@ const ArtistList = () => {
     const isDarkMode = options.generalOverrideSystemAppearance ? options.generalDarkmode : systemColorScheme === 'dark';
     const [startPlayback, setStartPlayback] = useState(false);
 
-    const sortedArtists = useMemo(() => (
-        [...artists].sort((a, b) => titleSort(a.artist, b.artist))
-    ), [artists]);
+    const sortedArtists = useMemo(() => [...artists].sort((a, b) => titleSort(a.artist, b.artist)), [artists]);
 
     useEffect(() => {
         if (navigation.isFocused() && currentPlaylist && startPlayback) {
             setStartPlayback(false);
-            TrackPlayer.add(convertSongListToTracks(currentPlaylist.playArray))
-                .then(() => {
-                    TrackPlayer.play();
-                    // @ts-ignore
-                    navigation.navigate('HomeTabs', { screen: 'Playback' });
-                });
+            TrackPlayer.add(convertSongListToTracks(currentPlaylist.playArray)).then(() => {
+                TrackPlayer.play();
+                // @ts-ignore
+                navigation.navigate('HomeTabs', {screen: 'Playback'});
+            });
         }
     }, [currentPlaylist, startPlayback]);
 
@@ -69,82 +66,92 @@ const ArtistList = () => {
                             options.randomizationShouldNotRepeatSongs
                         );
                         dispatch(setViewingPlayArray(initialSongs));
-                        TrackPlayer.add(convertSongListToTracks(initialSongs))
-                            .then(() => {
-                                TrackPlayer.play();
-                                // @ts-ignore
-                                navigation.navigate('Playback');
-                            });
+                        TrackPlayer.add(convertSongListToTracks(initialSongs)).then(() => {
+                            TrackPlayer.play();
+                            // @ts-ignore
+                            navigation.navigate('Playback');
+                        });
                     } else {
-                        TrackPlayer.add(convertSongListToTracks(currentPlaylist.playArray))
-                            .then(() => {
-                                TrackPlayer.play();
-                                // @ts-ignore
-                                navigation.navigate('Playback');
-                            });
+                        TrackPlayer.add(convertSongListToTracks(currentPlaylist.playArray)).then(() => {
+                            TrackPlayer.play();
+                            // @ts-ignore
+                            navigation.navigate('Playback');
+                        });
                     }
                 }
             });
         }
     }, []);
 
-    const renderArtist = ({ item }: { item: Artist }) => {
+    const renderArtist = ({item}: {item: Artist}) => {
         const sortedAlbums = [...item.albums].sort((a, b) => titleSort(a.albumName, b.albumName));
         return (
             <ComponentDropDown
-                mainItemCard={(<ArtistCard artist={item} />)}
-                subItemFlatlist={(
+                mainItemCard={<ArtistCard artist={item} searched={searched || undefined} />}
+                subItemFlatlist={
                     <FlatList
                         data={sortedAlbums}
-                        renderItem={({ item }: { item: Album }) => (
+                        renderItem={({item}: {item: Album}) => (
                             <ComponentDropDown
-                                mainItemCard={(<AlbumCard album={item} onPlay={async () => {
-                                    dispatch(setAlbumAsPlayingPlaylist(item));
-                                    await TrackPlayer.reset();
-                                    if (currentPlaylist) {
-                                        switch (playbackOptions.mode) {
-                                            case PlaybackMode.NORMAL:
-                                                const playArray = getPlayArray(currentPlaylist);
-                                                dispatch(setViewingPlayArray(playArray));
-                                                break;
-                                            case PlaybackMode.SHUFFLE:
-                                                dispatch(setViewingPlayArray(getPlayArray(currentPlaylist)));
-                                                dispatch(shuffleViewingPlaylist());
-                                                break;
-                                            case PlaybackMode.RANDOMIZE:
-                                                const initialSongs = getRandomizedSongs(
-                                                    currentPlaylist,
-                                                    options.randomizationForwardBuffer,
-                                                    playbackOptions.randomizeOptions.weighted,
-                                                    options.randomizationShouldNotRepeatSongs
-                                                );
-                                                dispatch(setViewingPlayArray(initialSongs));
-                                                break;
-                                            default:
-                                                return;
-                                        }
-                                        setStartPlayback(true);
-                                    }
-                                }} />)}  
-                                subItemFlatlist={(
+                                mainItemCard={
+                                    <AlbumCard
+                                        album={item}
+                                        onPlay={async () => {
+                                            dispatch(setAlbumAsPlayingPlaylist(item));
+                                            await TrackPlayer.reset();
+                                            if (currentPlaylist) {
+                                                switch (playbackOptions.mode) {
+                                                    case PlaybackMode.NORMAL:
+                                                        const playArray = getPlayArray(currentPlaylist);
+                                                        dispatch(setViewingPlayArray(playArray));
+                                                        break;
+                                                    case PlaybackMode.SHUFFLE:
+                                                        dispatch(setViewingPlayArray(getPlayArray(currentPlaylist)));
+                                                        dispatch(shuffleViewingPlaylist());
+                                                        break;
+                                                    case PlaybackMode.RANDOMIZE:
+                                                        const initialSongs = getRandomizedSongs(
+                                                            currentPlaylist,
+                                                            options.randomizationForwardBuffer,
+                                                            playbackOptions.randomizeOptions.weighted,
+                                                            options.randomizationShouldNotRepeatSongs
+                                                        );
+                                                        dispatch(setViewingPlayArray(initialSongs));
+                                                        break;
+                                                    default:
+                                                        return;
+                                                }
+                                                setStartPlayback(true);
+                                            }
+                                        }}
+                                        searched={searched || undefined}
+                                    />
+                                }
+                                subItemFlatlist={
                                     <FlatList
                                         data={item.songs}
-                                        renderItem={({ item }: { item: Song }) => (<SongCard song={item} colorScheme={isDarkMode ? 'dark' : 'light'} />)}
+                                        renderItem={({item}: {item: Song}) => (
+                                            <SongCard
+                                                song={item}
+                                                colorScheme={isDarkMode ? 'dark' : 'light'}
+                                                searched={searched || undefined}
+                                            />
+                                        )}
                                         keyExtractor={(item, index) => `${getSongId(item)}-${index}`}
                                         extraData={item}
                                     />
-                                )}
+                                }
                             />
                         )}
                         keyExtractor={(item, index) => `${getAlbumId(item)}-${index}`}
                         extraData={item}
                     />
-                )}
+                }
             />
-        )
+        );
     };
 
-    const itemSeparator = () => (<View style={styles.itemSeparator} />);
+    const itemSeparator = () => <View style={styles.itemSeparator} />;
 
     return (
         <SafeAreaView style={styles.container}>

--- a/src/components/Cards/AlbumCard/AlbumCard.tsx
+++ b/src/components/Cards/AlbumCard/AlbumCard.tsx
@@ -1,13 +1,9 @@
 import React from 'react';
-import {
-    Pressable,
-    Switch,
-    Text,
-    View
-} from 'react-native';
+import {Pressable, Switch, Text, View} from 'react-native';
 import MaterialCommunityIcons from 'react-native-vector-icons/MaterialCommunityIcons';
-import { Album } from '../../../models/MusicModel';
+import {Album} from '../../../models/MusicModel';
 import styles from './AlbumCard.style';
+import colorScheme from '../../../constant/Color';
 
 interface AlbumCardProps {
     album: Album;
@@ -15,43 +11,66 @@ interface AlbumCardProps {
     onRemove?: () => void;
     onAdd?: () => void;
     onPlay?: () => void;
+    searched?: string;
 }
 
 const AlbumCard = (props: AlbumCardProps) => {
-    const { album, setAlbumOrdered, onAdd, onRemove, onPlay } = props;
+    const {album, setAlbumOrdered, onAdd, onRemove, onPlay, searched} = props;
 
-    const orderedAlbumSelectorView = (ordered = false) => setAlbumOrdered && (
-        <View style={{...styles.infoView, flex: 1}}>
-            <Text style={styles.subsubtitle}>Order this album?</Text>
-            <Switch value={ordered} onValueChange={setAlbumOrdered} />
-        </View>
-    );
+    const orderedAlbumSelectorView = (ordered = false) =>
+        setAlbumOrdered && (
+            <View style={{...styles.infoView, flex: 1}}>
+                <Text style={styles.subsubtitle}>Order this album?</Text>
+                <Switch value={ordered} onValueChange={setAlbumOrdered} />
+            </View>
+        );
 
-    const removeView = () => onRemove && (
-        <Pressable onPress={onRemove}>
-            <MaterialCommunityIcons name="music-off" size={30} />
-        </Pressable>
-    );
+    const removeView = () =>
+        onRemove && (
+            <Pressable onPress={onRemove}>
+                <MaterialCommunityIcons name="music-off" size={30} />
+            </Pressable>
+        );
 
-    const playView = () => onPlay && (
-        <Pressable onPress={onPlay}>
-            <MaterialCommunityIcons name="play-outline" size={30} />
-        </Pressable>
-    );
+    const playView = () =>
+        onPlay && (
+            <Pressable onPress={onPlay}>
+                <MaterialCommunityIcons name="play-outline" size={30} />
+            </Pressable>
+        );
 
-    const addView = () => onAdd && (
-        <Pressable onPress={onAdd}>
-            <MaterialCommunityIcons name="plus-box-multiple-outline" size={30} />
-        </Pressable>
-    );
+    const addView = () =>
+        onAdd && (
+            <Pressable onPress={onAdd}>
+                <MaterialCommunityIcons name="plus-box-multiple-outline" size={30} />
+            </Pressable>
+        );
+
+    const getFoundColor = () => {
+        if (searched) {
+            if (album.albumName.includes(searched)) {
+                return 'yellow';
+            } else if (album.songs.some(song => song.title.includes(searched))) {
+                return 'orange';
+            }
+        }
+    };
 
     return (
         <View style={styles.cardView}>
             <MaterialCommunityIcons name="music-box-multiple-outline" size={40} />
             <View style={{...styles.infoView, flex: 3}}>
-                <Text style={styles.title}>{album.albumName}</Text>
+                <Text
+                    style={{
+                        ...styles.title,
+                        color: getFoundColor(),
+                    }}>
+                    {album.albumName}
+                </Text>
                 <Text style={styles.subtitle}>{album.artistName}</Text>
-                <Text style={styles.subtitle}>{`${album.songs.length} song${album.songs.length === 1 ? '' : 's'}`}</Text>
+                <Text style={styles.subtitle}>{`${album.songs.length} song${
+                    album.songs.length === 1 ? '' : 's'
+                }`}</Text>
             </View>
             {orderedAlbumSelectorView(album.ordered)}
             {playView()}

--- a/src/components/Cards/AlbumCard/AlbumCard.tsx
+++ b/src/components/Cards/AlbumCard/AlbumCard.tsx
@@ -3,7 +3,6 @@ import {Pressable, Switch, Text, View} from 'react-native';
 import MaterialCommunityIcons from 'react-native-vector-icons/MaterialCommunityIcons';
 import {Album} from '../../../models/MusicModel';
 import styles from './AlbumCard.style';
-import colorScheme from '../../../constant/Color';
 
 interface AlbumCardProps {
     album: Album;
@@ -13,6 +12,16 @@ interface AlbumCardProps {
     onPlay?: () => void;
     searched?: string;
 }
+
+export const getFoundColor = (album: Album, searched?: string) => {
+    if (searched) {
+        if (album.albumName.toLowerCase().includes(searched.toLowerCase())) {
+            return 'yellow';
+        } else if (album.songs.some(song => song.title.toLowerCase().includes(searched.toLowerCase()))) {
+            return 'orange';
+        }
+    }
+};
 
 const AlbumCard = (props: AlbumCardProps) => {
     const {album, setAlbumOrdered, onAdd, onRemove, onPlay, searched} = props;
@@ -46,16 +55,6 @@ const AlbumCard = (props: AlbumCardProps) => {
             </Pressable>
         );
 
-    const getFoundColor = () => {
-        if (searched) {
-            if (album.albumName.includes(searched)) {
-                return 'yellow';
-            } else if (album.songs.some(song => song.title.includes(searched))) {
-                return 'orange';
-            }
-        }
-    };
-
     return (
         <View style={styles.cardView}>
             <MaterialCommunityIcons name="music-box-multiple-outline" size={40} />
@@ -63,7 +62,7 @@ const AlbumCard = (props: AlbumCardProps) => {
                 <Text
                     style={{
                         ...styles.title,
-                        color: getFoundColor(),
+                        color: getFoundColor(album, searched)
                     }}>
                     {album.albumName}
                 </Text>

--- a/src/components/Cards/ArtistCard/ArtistCard.tsx
+++ b/src/components/Cards/ArtistCard/ArtistCard.tsx
@@ -11,6 +11,22 @@ interface ArtistCardProps {
     searched?: string;
 }
 
+export const getFoundColor = (artist: Artist, searched?: string) => {
+    if (searched) {
+        if (artist.artist.toLowerCase().includes(searched.toLowerCase())) {
+            return 'yellow';
+        } else if (
+            artist.albums.some(
+                album =>
+                    album.albumName.toLowerCase().includes(searched.toLowerCase()) ||
+                    album.songs.some(song => song.title.toLowerCase().includes(searched.toLowerCase()))
+            )
+        ) {
+            return 'orange';
+        }
+    }
+};
+
 const ArtistCard = (props: ArtistCardProps) => {
     const {artist, onAdd, onRemove, searched} = props;
 
@@ -28,26 +44,11 @@ const ArtistCard = (props: ArtistCardProps) => {
             </Pressable>
         );
 
-    const getFoundColor = () => {
-        if (searched) {
-            if (artist.artist.includes(searched)) {
-                return 'yellow';
-            } else if (
-                artist.albums.some(album =>
-                    album.albumName.includes(searched)
-                    || album.songs.some(song => song.title.includes(searched))
-                )
-            ) {
-                return 'orange';
-            }
-        }
-    };
-
     return (
         <View style={styles.cardView}>
             <MaterialCommunityIcons name="head" size={40} />
             <View style={styles.infoView}>
-                <Text style={styles.title}>{artist.artist}</Text>
+                <Text style={{...styles.title, color: getFoundColor(artist, searched)}}>{artist.artist}</Text>
                 <Text style={styles.subtitle}>{`${artist.albums.length} album${
                     artist.albums.length === 1 ? '' : 's'
                 }`}</Text>

--- a/src/components/Cards/ArtistCard/ArtistCard.tsx
+++ b/src/components/Cards/ArtistCard/ArtistCard.tsx
@@ -1,41 +1,61 @@
 import React from 'react';
-import { Pressable, Text, View } from 'react-native';
+import {Pressable, Text, View} from 'react-native';
 import MaterialCommunityIcons from 'react-native-vector-icons/MaterialCommunityIcons';
-import { Artist } from '../../../models/MusicModel';
+import {Artist} from '../../../models/MusicModel';
 import styles from './ArtistCard.style';
 
 interface ArtistCardProps {
     artist: Artist;
     onAdd?: () => void;
     onRemove?: () => void;
+    searched?: string;
 }
 
 const ArtistCard = (props: ArtistCardProps) => {
-    const { artist, onAdd, onRemove } = props;
+    const {artist, onAdd, onRemove, searched} = props;
 
-    const removeView = () => onRemove && (
-        <Pressable onPress={onRemove}>
-            <MaterialCommunityIcons name="minus-box-multiple" size={30} />
-        </Pressable>
-    );
+    const removeView = () =>
+        onRemove && (
+            <Pressable onPress={onRemove}>
+                <MaterialCommunityIcons name="minus-box-multiple" size={30} />
+            </Pressable>
+        );
 
-    const addView = () => onAdd && (
-        <Pressable onPress={onAdd}>
-            <MaterialCommunityIcons name="plus-box-multiple" size={30} />
-        </Pressable>
-    );
+    const addView = () =>
+        onAdd && (
+            <Pressable onPress={onAdd}>
+                <MaterialCommunityIcons name="plus-box-multiple" size={30} />
+            </Pressable>
+        );
+
+    const getFoundColor = () => {
+        if (searched) {
+            if (artist.artist.includes(searched)) {
+                return 'yellow';
+            } else if (
+                artist.albums.some(album =>
+                    album.albumName.includes(searched)
+                    || album.songs.some(song => song.title.includes(searched))
+                )
+            ) {
+                return 'orange';
+            }
+        }
+    };
 
     return (
         <View style={styles.cardView}>
             <MaterialCommunityIcons name="head" size={40} />
             <View style={styles.infoView}>
                 <Text style={styles.title}>{artist.artist}</Text>
-                <Text style={styles.subtitle}>{`${artist.albums.length} album${artist.albums.length === 1 ? '' : 's'}`}</Text>
+                <Text style={styles.subtitle}>{`${artist.albums.length} album${
+                    artist.albums.length === 1 ? '' : 's'
+                }`}</Text>
             </View>
             {addView()}
             {removeView()}
         </View>
-    )
-}
+    );
+};
 
 export default ArtistCard;

--- a/src/components/Cards/SongCard/SongCard.tsx
+++ b/src/components/Cards/SongCard/SongCard.tsx
@@ -1,10 +1,5 @@
 import React from 'react';
-import {
-    Dimensions,
-    Pressable,
-    Text,
-    View
-} from 'react-native';
+import {Dimensions, Pressable, Text, View} from 'react-native';
 import NumericInput from 'react-native-numeric-input';
 import MaterialCommunityIcons from 'react-native-vector-icons/MaterialCommunityIcons';
 import Animated, {
@@ -12,11 +7,11 @@ import Animated, {
     interpolate,
     SharedValue,
     useAnimatedStyle,
-    useDerivedValue
+    useDerivedValue,
 } from 'react-native-reanimated';
 import colorScheme from '../../../constant/Color';
-import { Song } from '../../../models/MusicModel';
-import styles, { MARGIN, SongCardHeight } from './SongCard.style';
+import {Song} from '../../../models/MusicModel';
+import styles, {MARGIN, SongCardHeight} from './SongCard.style';
 
 interface SongCardAnimatedProps {
     song: Song;
@@ -24,19 +19,20 @@ interface SongCardAnimatedProps {
     onAdd?: () => void;
     onWeightChange?: (value: number) => void;
     isPlaying?: boolean;
-    animated?: { index: number; yOffset: SharedValue<number> };
+    animated?: {index: number; yOffset: SharedValue<number>};
     colorScheme: string;
+    searched?: string;
 }
 
-const height = Dimensions.get('window').height * .5;
+const height = Dimensions.get('window').height * 0.5;
 const CARD_HEIGHT = SongCardHeight + 2 * MARGIN;
 
 const SongCard = (props: SongCardAnimatedProps) => {
-    const { song, onAdd, onRemove, onWeightChange, isPlaying, animated } = props;
+    const {song, onAdd, onRemove, onWeightChange, isPlaying, animated, searched} = props;
 
     let animatedStyle: Object = {};
     if (animated) {
-        const { index, yOffset } = animated;
+        const {index, yOffset} = animated;
         const position = useDerivedValue(() => {
             return index * CARD_HEIGHT - yOffset.value;
         });
@@ -44,94 +40,93 @@ const SongCard = (props: SongCardAnimatedProps) => {
         const topHeight = 0;
         const bottomHeight = height - CARD_HEIGHT;
         const appearHeight = height;
-    
+
         animatedStyle = useAnimatedStyle(() => {
-            const translateY = yOffset.value + interpolate(
-                yOffset.value,
-                [0, 0.0001 + index * CARD_HEIGHT],
-                [0, -index * CARD_HEIGHT],
-                { extrapolateRight: Extrapolation.CLAMP }
-            ) + interpolate(
-                position.value,
-                [bottomHeight, appearHeight],
-                [0, -CARD_HEIGHT / 4],
-                Extrapolation.CLAMP
-            );
-    
+            const translateY =
+                yOffset.value +
+                interpolate(yOffset.value, [0, 0.0001 + index * CARD_HEIGHT], [0, -index * CARD_HEIGHT], {
+                    extrapolateRight: Extrapolation.CLAMP,
+                }) +
+                interpolate(position.value, [bottomHeight, appearHeight], [0, -CARD_HEIGHT / 4], Extrapolation.CLAMP);
+
             const scale = interpolate(
                 position.value,
                 [disappearHeight, topHeight, bottomHeight, appearHeight],
                 [0.5, 1, 1, 0.5],
-                Extrapolation.CLAMP
+                Extrapolation.CLAMP,
             );
             const opacity = interpolate(
                 position.value,
                 [disappearHeight, topHeight, bottomHeight, appearHeight],
-                [0.5, 1, 1, 0.5]
+                [0.5, 1, 1, 0.5],
             );
-    
+
             return {
-                opacity, transform: [{ translateY }, { scale }]
-            }
+                opacity,
+                transform: [{translateY}, {scale}],
+            };
         });
     }
-    
-    const weightView = () => onWeightChange && (
-        <View style={{...styles.infoView, flex: 1}}>
-            <Text style={styles.subsubtitle}>Randomization weight</Text>
-            <NumericInput
-                value={song.weight}
-                minValue={1}
-                rounded
-                onChange={onWeightChange}
-                textColor={colorScheme[props.colorScheme].content}
-            />
-        </View>
-    );
 
-    const removeView = () => onRemove && (
-        <Pressable onPress={onRemove}>
-            <MaterialCommunityIcons name="music-note-off" size={30} />
-        </Pressable>
-    );
+    const weightView = () =>
+        onWeightChange && (
+            <View style={{...styles.infoView, flex: 1}}>
+                <Text style={styles.subsubtitle}>Randomization weight</Text>
+                <NumericInput
+                    value={song.weight}
+                    minValue={1}
+                    rounded
+                    onChange={onWeightChange}
+                    textColor={colorScheme[props.colorScheme].content}
+                />
+            </View>
+        );
 
-    const addView = () => onAdd && (
-        <Pressable onPress={onAdd}>
-            <MaterialCommunityIcons name="plus-box-outline" size={30} />
-        </Pressable>
-    );
+    const removeView = () =>
+        onRemove && (
+            <Pressable onPress={onRemove}>
+                <MaterialCommunityIcons name="music-note-off" size={30} />
+            </Pressable>
+        );
+
+    const addView = () =>
+        onAdd && (
+            <Pressable onPress={onAdd}>
+                <MaterialCommunityIcons name="plus-box-outline" size={30} />
+            </Pressable>
+        );
+
+    const getFoundColor = () => {
+        if (searched && song.title.includes(searched)) {
+            return 'yellow';
+        }
+    };
 
     const cardView = () => (
         <>
-        <MaterialCommunityIcons
-            name="music-box-outline"
-            size={40}
-            color={!isPlaying ? colorScheme[props.colorScheme].content : 'salmon'}
-        />
-        {/* <Text style={styles.indexNumber}>{`${song.position || song.numberInAlbum || ''})`}</Text> */}
-        <View style={{...styles.infoView, flex: 1}}>
-            <Text style={styles.title}>{song.title}</Text>
-            <Text style={styles.subtitle}>{song.albumName}</Text>
-        </View>
-        {weightView()}
-        {addView()}
-        {removeView()}
+            <MaterialCommunityIcons
+                name="music-box-outline"
+                size={40}
+                color={!isPlaying ? colorScheme[props.colorScheme].content : 'salmon'}
+            />
+            {/* <Text style={styles.indexNumber}>{`${song.position || song.numberInAlbum || ''})`}</Text> */}
+            <View style={{...styles.infoView, flex: 1}}>
+                <Text style={{...styles.title, color: getFoundColor()}}>{song.title}</Text>
+                <Text style={styles.subtitle}>{song.albumName}</Text>
+            </View>
+            {weightView()}
+            {addView()}
+            {removeView()}
         </>
     );
 
     return !animated ? (
-        <View
-            style={[styles.cardView, { borderColor: colorScheme[props.colorScheme].outline }]}
-        >
-            {cardView()}
-        </View>
+        <View style={[styles.cardView, {borderColor: colorScheme[props.colorScheme].outline}]}>{cardView()}</View>
     ) : (
-        <Animated.View
-            style={[styles.cardView, { borderColor: colorScheme[props.colorScheme].outline }, animatedStyle]}
-        >
+        <Animated.View style={[styles.cardView, {borderColor: colorScheme[props.colorScheme].outline}, animatedStyle]}>
             {cardView()}
         </Animated.View>
-    )
+    );
 };
 
 export default SongCard;

--- a/src/components/Cards/SongCard/SongCard.tsx
+++ b/src/components/Cards/SongCard/SongCard.tsx
@@ -7,7 +7,7 @@ import Animated, {
     interpolate,
     SharedValue,
     useAnimatedStyle,
-    useDerivedValue,
+    useDerivedValue
 } from 'react-native-reanimated';
 import colorScheme from '../../../constant/Color';
 import {Song} from '../../../models/MusicModel';
@@ -27,6 +27,12 @@ interface SongCardAnimatedProps {
 const height = Dimensions.get('window').height * 0.5;
 const CARD_HEIGHT = SongCardHeight + 2 * MARGIN;
 
+export const getFoundColor = (song: Song, searched?: string) => {
+    if (searched && song.title.toLowerCase().includes(searched.toLowerCase())) {
+        return 'yellow';
+    }
+};
+
 const SongCard = (props: SongCardAnimatedProps) => {
     const {song, onAdd, onRemove, onWeightChange, isPlaying, animated, searched} = props;
 
@@ -45,7 +51,7 @@ const SongCard = (props: SongCardAnimatedProps) => {
             const translateY =
                 yOffset.value +
                 interpolate(yOffset.value, [0, 0.0001 + index * CARD_HEIGHT], [0, -index * CARD_HEIGHT], {
-                    extrapolateRight: Extrapolation.CLAMP,
+                    extrapolateRight: Extrapolation.CLAMP
                 }) +
                 interpolate(position.value, [bottomHeight, appearHeight], [0, -CARD_HEIGHT / 4], Extrapolation.CLAMP);
 
@@ -53,17 +59,17 @@ const SongCard = (props: SongCardAnimatedProps) => {
                 position.value,
                 [disappearHeight, topHeight, bottomHeight, appearHeight],
                 [0.5, 1, 1, 0.5],
-                Extrapolation.CLAMP,
+                Extrapolation.CLAMP
             );
             const opacity = interpolate(
                 position.value,
                 [disappearHeight, topHeight, bottomHeight, appearHeight],
-                [0.5, 1, 1, 0.5],
+                [0.5, 1, 1, 0.5]
             );
 
             return {
                 opacity,
-                transform: [{translateY}, {scale}],
+                transform: [{translateY}, {scale}]
             };
         });
     }
@@ -96,12 +102,6 @@ const SongCard = (props: SongCardAnimatedProps) => {
             </Pressable>
         );
 
-    const getFoundColor = () => {
-        if (searched && song.title.includes(searched)) {
-            return 'yellow';
-        }
-    };
-
     const cardView = () => (
         <>
             <MaterialCommunityIcons
@@ -111,7 +111,7 @@ const SongCard = (props: SongCardAnimatedProps) => {
             />
             {/* <Text style={styles.indexNumber}>{`${song.position || song.numberInAlbum || ''})`}</Text> */}
             <View style={{...styles.infoView, flex: 1}}>
-                <Text style={{...styles.title, color: getFoundColor()}}>{song.title}</Text>
+                <Text style={{...styles.title, color: getFoundColor(song, searched)}}>{song.title}</Text>
                 <Text style={styles.subtitle}>{song.albumName}</Text>
             </View>
             {weightView()}

--- a/src/components/PlaybackControl/PlaybackControl.tsx
+++ b/src/components/PlaybackControl/PlaybackControl.tsx
@@ -111,6 +111,7 @@ const PlaybackControl = (props: PlaybackControlProps) => {
                         seek(Math.floor(value));
                         setSeeking(false);
                     }}
+                    thumbTouchSize={{ height: 60, width: 60}}
                 />
                 <View style={styles.progressRow}>
                     <Text>{getMinSec(progress.position || 0)}</Text>

--- a/src/navigators/HomeStackNavigator.tsx
+++ b/src/navigators/HomeStackNavigator.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, {useMemo, useState} from 'react';
 import {Pressable, View} from 'react-native';
 import {createNativeStackNavigator} from '@react-navigation/native-stack';
 import {NavigationProp} from '@react-navigation/native';
@@ -74,25 +74,35 @@ const HomeStack = () => {
         </Pressable>
     );
 
+    const icon = useMemo(() => {
+        switch (searchType) {
+            case 'filter':
+                return 'magnify-close';
+            case 'find':
+                return 'magnify-plus';
+            default:
+                return 'magnify';
+        }
+    }, [searchType]);
     const searchButton = () => {
         if (currentTab !== 'Home') {
             return;
         }
-        let icon: string;
-        let next: SearchType;
-        switch (searchType) {
-            case 'filter':
-                icon = 'magnify-close';
-                next = 'none';
-            case 'find':
-                icon = 'magnify-plus';
-                next = 'filter';
-            default:
-                icon = 'magnify';
-                next = 'find';
-        }
         return (
-            <Pressable style={styles.optionButton} onPress={() => setSearchType(next)}>
+            <Pressable
+                style={styles.optionButton}
+                onPress={() =>
+                    setSearchType(current => {
+                        switch (current) {
+                            case 'filter':
+                                return 'none';
+                            case 'find':
+                                return 'filter';
+                            default:
+                                return 'find';
+                        }
+                    })
+                }>
                 <MaterialCommunityIcons name={icon} size={30} />
             </Pressable>
         );

--- a/src/navigators/HomeStackNavigator.tsx
+++ b/src/navigators/HomeStackNavigator.tsx
@@ -1,19 +1,19 @@
-import React, { useState } from 'react';
-import { Pressable, View } from 'react-native';
-import { createNativeStackNavigator } from '@react-navigation/native-stack';
-import { NavigationProp } from '@react-navigation/native';
-import TrackPlayer, { State, usePlaybackState } from 'react-native-track-player';
+import React, {useState} from 'react';
+import {Pressable, View} from 'react-native';
+import {createNativeStackNavigator} from '@react-navigation/native-stack';
+import {NavigationProp} from '@react-navigation/native';
+import TrackPlayer, {State, usePlaybackState} from 'react-native-track-player';
 import Icon from 'react-native-vector-icons/AntDesign';
 import MaterialCommunityIcons from 'react-native-vector-icons/MaterialCommunityIcons';
 import styles from './HomeNavigator.style';
 import ArtistScreen from '../screens/ArtistScreen/ArtistScreen';
 import NewPlaylist from '../screens/NewPlaylist/NewPlaylist';
 import Playlist from '../screens/Playlist/Playlist';
-import { useTypedSelector } from '../state/reducers';
+import {useTypedSelector} from '../state/reducers';
 import HomeTabs from './HomeTabsNavigator';
-import { playable } from '../utils/trackPlayUtils';
-import { useDispatch } from 'react-redux';
-import { setPlaylistToEdit } from '../state/actions/Playlist';
+import {playable} from '../utils/trackPlayUtils';
+import {useDispatch} from 'react-redux';
+import {setPlaylistToEdit} from '../state/actions/Playlist';
 
 export type HomeStackNavigatorParams = {
     HomeTabs: undefined;
@@ -23,29 +23,36 @@ export type HomeStackNavigatorParams = {
 };
 const Stack = createNativeStackNavigator<HomeStackNavigatorParams>();
 
+export type SearchType = 'none' | 'find' | 'filter';
+
 const HomeStack = () => {
     const currentArtist = useTypedSelector(state => state.Albums.selectedArtist);
-    const { savedPlaylists } = useTypedSelector(state => state.Playlist);
-    const { newPlaylist } = useTypedSelector(state => state.Playlist);
-    const { viewingPlaylist }  = useTypedSelector(state => state.Playlist);
+    const {savedPlaylists} = useTypedSelector(state => state.Playlist);
+    const {newPlaylist} = useTypedSelector(state => state.Playlist);
+    const {viewingPlaylist} = useTypedSelector(state => state.Playlist);
     const viewingPlaylistName = viewingPlaylist?.name;
     const dispatch = useDispatch();
     const playbackState = usePlaybackState();
     const [currentTab, setCurrentTab] = useState('Home');
+    const [searchType, setSearchType] = useState<SearchType>('none');
     const playing = playbackState === State.Playing;
 
-    const playbackButton = () => playable(playbackState) && (playing ? (
-        <Pressable style={styles.optionButton} onPress={TrackPlayer.pause}>
-            <Icon name="caretright" size={20} />
-        </Pressable>
-    ) : (
-        <Pressable style={styles.optionButton} onPress={TrackPlayer.play}>
-            <Icon name="pause" size={20} />
-        </Pressable>
-    ));
+    const playbackButton = () =>
+        playable(playbackState) &&
+        (playing ? (
+            <Pressable style={styles.optionButton} onPress={TrackPlayer.pause}>
+                <Icon name="caretright" size={20} />
+            </Pressable>
+        ) : (
+            <Pressable style={styles.optionButton} onPress={TrackPlayer.play}>
+                <Icon name="pause" size={20} />
+            </Pressable>
+        ));
 
     const playlistButton = (navigation: NavigationProp<any>) => (
-        <Pressable style={styles.optionButton} onPress={() => navigation.navigate(savedPlaylists.length ? 'PlaylistList' : 'NewPlaylist')}>
+        <Pressable
+            style={styles.optionButton}
+            onPress={() => navigation.navigate(savedPlaylists.length ? 'PlaylistList' : 'NewPlaylist')}>
             <MaterialCommunityIcons name={savedPlaylists.length ? 'playlist-music' : 'playlist-plus'} size={25} />
         </Pressable>
     );
@@ -57,33 +64,69 @@ const HomeStack = () => {
     );
 
     const editPlaylistButton = (navigation: NavigationProp<any>) => (
-        <Pressable style={styles.optionButton} onPress={() => {
-            dispatch(setPlaylistToEdit());
-            navigation.navigate('NewPlaylist')
-        }}>
+        <Pressable
+            style={styles.optionButton}
+            onPress={() => {
+                dispatch(setPlaylistToEdit());
+                navigation.navigate('NewPlaylist');
+            }}>
             <MaterialCommunityIcons name="playlist-edit" size={30} />
         </Pressable>
-    );    
+    );
+
+    const searchButton = () => {
+        if (currentTab !== 'Home') {
+            return;
+        }
+        let icon: string;
+        let next: SearchType;
+        switch (searchType) {
+            case 'filter':
+                icon = 'magnify-close';
+                next = 'none';
+            case 'find':
+                icon = 'magnify-plus';
+                next = 'filter';
+            default:
+                icon = 'magnify';
+                next = 'find';
+        }
+        return (
+            <Pressable style={styles.optionButton} onPress={() => setSearchType(next)}>
+                <MaterialCommunityIcons name={icon} size={30} />
+            </Pressable>
+        );
+    };
+    const resetSearch = () => setSearchType('none');
 
     return (
         <Stack.Navigator>
             <Stack.Screen
                 name="HomeTabs"
-                options={({ navigation }: { navigation: NavigationProp<any> }) => ({
+                options={({navigation}: {navigation: NavigationProp<any>}) => ({
                     headerTitle: 'Home',
                     headerRight: () => (
                         <View style={styles.headerContainer}>
                             {currentTab === 'PlaylistList' ? addPlaylistButton(navigation) : playlistButton(navigation)}
                             {playbackButton()}
+                            {searchButton()}
                         </View>
                     )
-                })}
-            >{props => <HomeTabs currentTab={currentTab} setCurrentTab={setCurrentTab} />}</Stack.Screen>
+                })}>
+                {props => (
+                    <HomeTabs
+                        currentTab={currentTab}
+                        setCurrentTab={setCurrentTab}
+                        searchType={searchType}
+                        resetSearch={resetSearch}
+                    />
+                )}
+            </Stack.Screen>
             <Stack.Screen
                 name="ArtistScreen"
                 component={ArtistScreen}
                 options={{
-                    headerTitle: `${currentArtist && currentArtist.artist || 'Artist'}`
+                    headerTitle: `${(currentArtist && currentArtist.artist) || 'Artist'}`
                 }}
             />
             <Stack.Screen
@@ -96,11 +139,9 @@ const HomeStack = () => {
             <Stack.Screen
                 name="Playlist"
                 component={Playlist}
-                options={({ navigation }: { navigation: NavigationProp<any> }) => ({
+                options={({navigation}: {navigation: NavigationProp<any>}) => ({
                     headerTitle: `Playlist${viewingPlaylist ? ' - ' + viewingPlaylistName : ''}`,
-                    headerRight: () => (
-                        editPlaylistButton(navigation)
-                    )
+                    headerRight: () => editPlaylistButton(navigation)
                 })}
             />
         </Stack.Navigator>

--- a/src/navigators/HomeTabsNavigator.tsx
+++ b/src/navigators/HomeTabsNavigator.tsx
@@ -1,13 +1,13 @@
-import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
-import { useNavigation } from '@react-navigation/native';
-import React, { useState } from 'react';
-import { usePlaybackState } from 'react-native-track-player';
+import {createBottomTabNavigator} from '@react-navigation/bottom-tabs';
+import {useNavigation} from '@react-navigation/native';
+import React, {useEffect, useState} from 'react';
+import {usePlaybackState} from 'react-native-track-player';
 import MaterialCommunityIcons from 'react-native-vector-icons/MaterialCommunityIcons';
 import Home from '../screens/Home/Home';
 import Playback from '../screens/PlaybackScreen/Playback';
 import PlaylistList from '../screens/PlaylistList/PlaylistList';
-import { SearchType } from './HomeStackNavigator';
-import { TextInput } from 'react-native';
+import {SearchType} from './HomeStackNavigator';
+import {TextInput} from 'react-native';
 
 export type HomeTabNavParams = {
     Home: undefined;
@@ -24,7 +24,7 @@ interface TabNavProps {
 }
 
 const HomeTabs = (props: TabNavProps) => {
-    const { searchType, resetSearch, currentTab, setCurrentTab } = props;
+    const {searchType, resetSearch, currentTab, setCurrentTab} = props;
     const [searched, setSearched] = useState('');
     const playbackState = usePlaybackState();
     const navigation = useNavigation();
@@ -41,12 +41,22 @@ const HomeTabs = (props: TabNavProps) => {
         <MaterialCommunityIcons name="playlist-play" size={size} color={color} />
     );
 
+    useEffect(() => {
+        if (searchType === 'none') {
+            setSearched('');
+        }
+    }, [searchType]);
+
     const searchBarView = () => (
-        <TextInput value={searched} onChangeText={setSearched} onEndEditing={() => {
-            if (!searched) {
-                resetSearch();
-            }
-        }}/>
+        <TextInput
+            value={searched}
+            onChangeText={setSearched}
+            onEndEditing={() => {
+                if (!searched) {
+                    resetSearch();
+                }
+            }}
+        />
     );
 
     return (
@@ -55,8 +65,7 @@ const HomeTabs = (props: TabNavProps) => {
             screenOptions={{
                 headerShown: currentTab === 'Home' && searchType !== 'none',
                 header: searchBarView
-            }}
-        >
+            }}>
             <Tab.Screen
                 name="Home"
                 listeners={{
@@ -64,8 +73,9 @@ const HomeTabs = (props: TabNavProps) => {
                 }}
                 options={{
                     tabBarIcon: props => homeIcon(props.size, props.color)
-                }}
-            >{props => <Home searched={searched} />}</Tab.Screen>
+                }}>
+                {props => <Home searched={searched} isFilteredSearch={searchType === 'filter'} />}
+            </Tab.Screen>
             <Tab.Screen
                 name="PlaylistList"
                 component={PlaylistList}

--- a/src/navigators/HomeTabsNavigator.tsx
+++ b/src/navigators/HomeTabsNavigator.tsx
@@ -1,11 +1,13 @@
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { useNavigation } from '@react-navigation/native';
-import React, { useEffect } from 'react';
+import React, { useState } from 'react';
 import { usePlaybackState } from 'react-native-track-player';
 import MaterialCommunityIcons from 'react-native-vector-icons/MaterialCommunityIcons';
 import Home from '../screens/Home/Home';
 import Playback from '../screens/PlaybackScreen/Playback';
 import PlaylistList from '../screens/PlaylistList/PlaylistList';
+import { SearchType } from './HomeStackNavigator';
+import { TextInput } from 'react-native';
 
 export type HomeTabNavParams = {
     Home: undefined;
@@ -17,9 +19,13 @@ const Tab = createBottomTabNavigator<HomeTabNavParams>();
 interface TabNavProps {
     currentTab: string;
     setCurrentTab: React.Dispatch<React.SetStateAction<string>>;
+    searchType: SearchType;
+    resetSearch: () => void;
 }
 
 const HomeTabs = (props: TabNavProps) => {
+    const { searchType, resetSearch, currentTab, setCurrentTab } = props;
+    const [searched, setSearched] = useState('');
     const playbackState = usePlaybackState();
     const navigation = useNavigation();
 
@@ -35,28 +41,36 @@ const HomeTabs = (props: TabNavProps) => {
         <MaterialCommunityIcons name="playlist-play" size={size} color={color} />
     );
 
+    const searchBarView = () => (
+        <TextInput value={searched} onChangeText={setSearched} onEndEditing={() => {
+            if (!searched) {
+                resetSearch();
+            }
+        }}/>
+    );
+
     return (
         <Tab.Navigator
             initialRouteName="Home"
             screenOptions={{
-                headerShown: false
+                headerShown: currentTab === 'Home' && searchType !== 'none',
+                header: searchBarView
             }}
         >
             <Tab.Screen
                 name="Home"
-                component={Home}
                 listeners={{
-                    focus: () => props.setCurrentTab('Home')
+                    focus: () => setCurrentTab('Home')
                 }}
                 options={{
                     tabBarIcon: props => homeIcon(props.size, props.color)
                 }}
-            />
+            >{props => <Home searched={searched} />}</Tab.Screen>
             <Tab.Screen
                 name="PlaylistList"
                 component={PlaylistList}
                 listeners={{
-                    focus: () => props.setCurrentTab('PlaylistList')
+                    focus: () => setCurrentTab('PlaylistList')
                 }}
                 options={{
                     tabBarIcon: props => playlistListIcon(props.size, props.color)
@@ -66,7 +80,7 @@ const HomeTabs = (props: TabNavProps) => {
                 name="Playback"
                 component={Playback}
                 listeners={{
-                    focus: () => props.setCurrentTab('Playback')
+                    focus: () => setCurrentTab('Playback')
                 }}
                 options={{
                     tabBarIcon: props => playbackIcon(props.size, props.color)

--- a/src/screens/Home/Home.tsx
+++ b/src/screens/Home/Home.tsx
@@ -3,9 +3,13 @@ import { SafeAreaView } from 'react-native';
 import ArtistList from '../../components/ArtistListComponent/ArtistListComponent';
 import styles from './Home.style';
 
-const Home = () => (
+interface HomeProps {
+    searched: string;
+}
+
+const Home = (props: HomeProps) => (
     <SafeAreaView style={styles.container}>
-        <ArtistList />
+        <ArtistList searched={props.searched} />
     </SafeAreaView>
 );
 

--- a/src/screens/Home/Home.tsx
+++ b/src/screens/Home/Home.tsx
@@ -1,17 +1,17 @@
 import React from 'react';
-import { SafeAreaView } from 'react-native';
+import {SafeAreaView} from 'react-native';
 import ArtistList from '../../components/ArtistListComponent/ArtistListComponent';
 import styles from './Home.style';
 
 interface HomeProps {
+    isFilteredSearch: boolean;
     searched: string;
 }
 
 const Home = (props: HomeProps) => (
     <SafeAreaView style={styles.container}>
-        <ArtistList searched={props.searched} />
+        <ArtistList isFilteredSearch={props.isFilteredSearch} searched={props.searched} />
     </SafeAreaView>
 );
-
 
 export default Home;

--- a/src/screens/PlaybackScreen/Playback.tsx
+++ b/src/screens/PlaybackScreen/Playback.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useRef, useState} from 'react';
+import React, {useEffect, useMemo, useRef, useState} from 'react';
 import {Pressable, useColorScheme, View} from 'react-native';
 import {SafeAreaView} from 'react-native-safe-area-context';
 import TrackPlayer, {Event, RepeatMode, State, usePlaybackState, useTrackPlayerEvents} from 'react-native-track-player';
@@ -187,7 +187,7 @@ const Playback = () => {
         }
     });
 
-    const renderSongCard = ({item, index}: {item: Song; index: number}) => (
+    const renderSongCard = useMemo(() => ({item, index}: {item: Song; index: number}) => (
         <Pressable onPress={async () => await TrackPlayer.skip(index)}>
             <SongCard
                 song={item}
@@ -196,7 +196,7 @@ const Playback = () => {
                 animated={{index, yOffset: translationY}}
             />
         </Pressable>
-    );
+    ), [!!currentSong, currentTrack]);
 
     const songView = () =>
         !!(playingPlaylist && currentSong) && (

--- a/src/screens/PlaybackScreen/Playback.tsx
+++ b/src/screens/PlaybackScreen/Playback.tsx
@@ -1,37 +1,32 @@
-import React, { useEffect, useRef, useState } from 'react';
-import { Pressable, useColorScheme, View } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
-import TrackPlayer, {
-    Event,
-    RepeatMode,
-    usePlaybackState,
-    useTrackPlayerEvents
-} from 'react-native-track-player';
+import React, {useEffect, useRef, useState} from 'react';
+import {Pressable, useColorScheme, View} from 'react-native';
+import {SafeAreaView} from 'react-native-safe-area-context';
+import TrackPlayer, {Event, RepeatMode, State, usePlaybackState, useTrackPlayerEvents} from 'react-native-track-player';
 import BackgroundTimer from 'react-native-background-timer';
-import Animated, { useAnimatedScrollHandler, useSharedValue } from 'react-native-reanimated';
-import { useFocusEffect } from '@react-navigation/native';
-import { useDispatch } from 'react-redux';
+import Animated, {useAnimatedScrollHandler, useSharedValue} from 'react-native-reanimated';
+import {useFocusEffect} from '@react-navigation/native';
+import {useDispatch} from 'react-redux';
 import SongCard from '../../components/Cards/SongCard/SongCard';
 import PlaybackControl from '../../components/PlaybackControl/PlaybackControl';
-import { Song } from '../../models/MusicModel';
-import { convertSongListToTracks, getSongId } from '../../utils/musicUtils';
-import { getRandomizedNextSong, getRandomizedSongs } from '../../utils/PlaylistRandomization';
-import { playable } from '../../utils/trackPlayUtils';
-import { useTypedSelector } from '../../state/reducers';
+import {Song} from '../../models/MusicModel';
+import {convertSongListToTracks, getSongId} from '../../utils/musicUtils';
+import {getRandomizedNextSong, getRandomizedSongs} from '../../utils/PlaylistRandomization';
+import {playable} from '../../utils/trackPlayUtils';
+import {useTypedSelector} from '../../state/reducers';
 import {
     removeOldestRandomSongs,
     setViewingPlayArray,
     setLastSongPlayed,
     setRandomNextSongs
 } from '../../state/actions/Playlist';
-import { PlaybackMode } from '../../state/reducers/Playlist';
-import { MARGIN, SongCardHeight } from '../../components/Cards/SongCard/SongCard.style';
+import {PlaybackMode} from '../../state/reducers/Playlist';
+import {MARGIN, SongCardHeight} from '../../components/Cards/SongCard/SongCard.style';
 import styles from './Playback.style';
 
 const CARD_HEIGHT = SongCardHeight + MARGIN * 2;
 
 const Playback = () => {
-    const { playingPlaylist, playbackOptions } = useTypedSelector(state => state.Playlist);
+    const {playingPlaylist, playbackOptions, viewingPlaylist} = useTypedSelector(state => state.Playlist);
     const options = useTypedSelector(state => state.Options);
     const dispatch = useDispatch();
     const playbackState = usePlaybackState();
@@ -44,7 +39,7 @@ const Playback = () => {
     const isDarkMode = options.generalOverrideSystemAppearance ? options.generalDarkmode : systemColorScheme === 'dark';
 
     const translationY = useSharedValue(0);
-    const scrollHandler = useAnimatedScrollHandler((event) => {
+    const scrollHandler = useAnimatedScrollHandler(event => {
         translationY.value = event.contentOffset.y;
     });
 
@@ -82,23 +77,27 @@ const Playback = () => {
             TrackPlayer.getCurrentTrack().then(currentIndex => {
                 if (currentIndex) {
                     if (playbackOptions.mode === PlaybackMode.RANDOMIZE && playingPlaylist) {
-                        const { randomizationForwardBuffer, randomizationBackwardBuffer } = options;
+                        const {randomizationForwardBuffer, randomizationBackwardBuffer} = options;
                         const totalBuffer = randomizationBackwardBuffer + randomizationForwardBuffer;
                         const totalCurrentSongs = playingPlaylist && playingPlaylist.playArray.length;
                         const currentForwardBuffer = totalCurrentSongs - currentIndex;
-    
+
                         // We need to add when the forward buffer is smaller than we need
                         if (currentForwardBuffer < randomizationForwardBuffer) {
                             const bufferNeeded = randomizationForwardBuffer - currentForwardBuffer;
                             const songsToAdd: Song[] = [];
                             if (options.randomizationShouldNotRepeatSongs) {
-                                songsToAdd.push(getRandomizedNextSong(
-                                    playingPlaylist,
-                                    playbackOptions.randomizeOptions.weighted,
-                                    playingPlaylist.playArray[playingPlaylist.playArray.length - 1]
-                                ));
+                                songsToAdd.push(
+                                    getRandomizedNextSong(
+                                        playingPlaylist,
+                                        playbackOptions.randomizeOptions.weighted,
+                                        playingPlaylist.playArray[playingPlaylist.playArray.length - 1]
+                                    )
+                                );
                             } else {
-                                songsToAdd.push(getRandomizedNextSong(playingPlaylist, playbackOptions.randomizeOptions.weighted));
+                                songsToAdd.push(
+                                    getRandomizedNextSong(playingPlaylist, playbackOptions.randomizeOptions.weighted)
+                                );
                             }
                             for (let i = 1; i < bufferNeeded; i++) {
                                 let nextSong: Song;
@@ -118,7 +117,7 @@ const Playback = () => {
                             }
                             dispatch(setRandomNextSongs(songsToAdd));
                             TrackPlayer.add(convertSongListToTracks(songsToAdd));
-    
+
                             // We need to remove when we have more than the total buffer
                             if (totalCurrentSongs > totalBuffer) {
                                 const songsToRemove = totalCurrentSongs - totalBuffer;
@@ -126,6 +125,11 @@ const Playback = () => {
                                 dispatch(removeOldestRandomSongs(songsToRemove));
                                 // We need to subtract here however many songs we removed
                                 currentIndex = currentIndex - songsToRemove;
+                            }
+
+                            // Trackplayer appears to be pausing on current track
+                            if (playbackState !== State.Playing) {
+                                TrackPlayer.play();
                             }
                         }
                     }
@@ -162,8 +166,8 @@ const Playback = () => {
             }
             TrackPlayer.play();
         }
-    }
-    
+    };
+
     const scrollToCurrent = () => {
         setCurrentSong(playingPlaylist?.playArray[currentTrack]);
         // @ts-ignore
@@ -178,38 +182,37 @@ const Playback = () => {
         scrollToCurrent();
     }, [currentTrack]);
     useFocusEffect(() => {
-        scrollToCurrent();
+        if (viewingPlaylist?.lastSongPlayed ?? -1 >= 0) {
+            setCurrentTrack(viewingPlaylist?.lastSongPlayed || 0);
+        }
     });
 
-    const renderSongCard = ({ item, index }: { item: Song, index: number }) => (
+    const renderSongCard = ({item, index}: {item: Song; index: number}) => (
         <Pressable onPress={async () => await TrackPlayer.skip(index)}>
             <SongCard
                 song={item}
                 colorScheme={isDarkMode ? 'dark' : 'light'}
                 isPlaying={currentSong && currentTrack === index}
-                animated={{ index, yOffset: translationY }}
+                animated={{index, yOffset: translationY}}
             />
         </Pressable>
     );
 
-    const songView = () => !!(playingPlaylist && currentSong) && (
-        <View style={styles.scrollView}>
-            <Animated.FlatList
-                data={playingPlaylist.playArray}
-                renderItem={renderSongCard}
-                keyExtractor={(item, index) => getSongId(item) + index}
-                onScroll={scrollHandler}
-                scrollEventThrottle={16}
-                ref={pickerRef}
-                getItemLayout={(_data, index) => (
-                    {length: CARD_HEIGHT, offset: CARD_HEIGHT * index, index}
-                )}
-                ListFooterComponent={(
-                    <View style={{ height: 1.5 * CARD_HEIGHT }} />
-                )}
-            />
-        </View>
-    );
+    const songView = () =>
+        !!(playingPlaylist && currentSong) && (
+            <View style={styles.scrollView}>
+                <Animated.FlatList
+                    data={playingPlaylist.playArray}
+                    renderItem={renderSongCard}
+                    keyExtractor={(item, index) => getSongId(item) + index}
+                    onScroll={scrollHandler}
+                    scrollEventThrottle={16}
+                    ref={pickerRef}
+                    getItemLayout={(_data, index) => ({length: CARD_HEIGHT, offset: CARD_HEIGHT * index, index})}
+                    ListFooterComponent={<View style={{height: 1.5 * CARD_HEIGHT}} />}
+                />
+            </View>
+        );
 
     return (
         <SafeAreaView style={styles.container}>
@@ -226,7 +229,7 @@ const Playback = () => {
                 setRepeatMode={setRepeatMode}
             />
         </SafeAreaView>
-    )
+    );
 };
 
 export default Playback;

--- a/src/screens/PlaybackScreen/Playback.tsx
+++ b/src/screens/PlaybackScreen/Playback.tsx
@@ -8,24 +8,25 @@ import TrackPlayer, {
     useTrackPlayerEvents
 } from 'react-native-track-player';
 import BackgroundTimer from 'react-native-background-timer';
+import Animated, { useAnimatedScrollHandler, useSharedValue } from 'react-native-reanimated';
+import { useFocusEffect } from '@react-navigation/native';
+import { useDispatch } from 'react-redux';
 import SongCard from '../../components/Cards/SongCard/SongCard';
 import PlaybackControl from '../../components/PlaybackControl/PlaybackControl';
 import { Song } from '../../models/MusicModel';
-import { useTypedSelector } from '../../state/reducers';
 import { convertSongListToTracks, getSongId } from '../../utils/musicUtils';
-import styles from './Playback.style';
-import { useDispatch } from 'react-redux';
+import { getRandomizedNextSong, getRandomizedSongs } from '../../utils/PlaylistRandomization';
+import { playable } from '../../utils/trackPlayUtils';
+import { useTypedSelector } from '../../state/reducers';
 import {
     removeOldestRandomSongs,
     setViewingPlayArray,
     setLastSongPlayed,
     setRandomNextSongs
 } from '../../state/actions/Playlist';
-import { playable } from '../../utils/trackPlayUtils';
-import Animated, { useAnimatedScrollHandler, useSharedValue } from 'react-native-reanimated';
-import { MARGIN, SongCardHeight } from '../../components/Cards/SongCard/SongCard.style';
 import { PlaybackMode } from '../../state/reducers/Playlist';
-import { getRandomizedNextSong, getRandomizedSongs } from '../../utils/PlaylistRandomization';
+import { MARGIN, SongCardHeight } from '../../components/Cards/SongCard/SongCard.style';
+import styles from './Playback.style';
 
 const CARD_HEIGHT = SongCardHeight + MARGIN * 2;
 
@@ -162,8 +163,8 @@ const Playback = () => {
             TrackPlayer.play();
         }
     }
-
-    useEffect(() => {
+    
+    const scrollToCurrent = () => {
         setCurrentSong(playingPlaylist?.playArray[currentTrack]);
         // @ts-ignore
         pickerRef.current?.scrollToIndex({
@@ -171,7 +172,14 @@ const Playback = () => {
             index: currentTrack,
             viewPosition: 0.5
         });
+    };
+
+    useEffect(() => {
+        scrollToCurrent();
     }, [currentTrack]);
+    useFocusEffect(() => {
+        scrollToCurrent();
+    });
 
     const renderSongCard = ({ item, index }: { item: Song, index: number }) => (
         <Pressable onPress={async () => await TrackPlayer.skip(index)}>
@@ -193,8 +201,11 @@ const Playback = () => {
                 onScroll={scrollHandler}
                 scrollEventThrottle={16}
                 ref={pickerRef}
-                getItemLayout={(data, index) => (
+                getItemLayout={(_data, index) => (
                     {length: CARD_HEIGHT, offset: CARD_HEIGHT * index, index}
+                )}
+                ListFooterComponent={(
+                    <View style={{ height: 1.5 * CARD_HEIGHT }} />
                 )}
             />
         </View>

--- a/src/state/reducers/Playlist.ts
+++ b/src/state/reducers/Playlist.ts
@@ -192,9 +192,14 @@ export const Playlist = (state = initialState, action: Actions): PlaylistState =
             };
         case SET_CURRENT_AS_PLAYING: {
             const toPlay = _.cloneDeep(state.viewingPlaylist);
+            let viewing: PlaylistModel | null = null;
+            if (toPlay) {
+                viewing = {...toPlay, lastSongPlayed: 0};
+            }
             return {
                 ...state,
-                playingPlaylist: toPlay
+                playingPlaylist: toPlay,
+                viewingPlaylist: viewing
             }
         }
         case SET_ALBUM_ORDERED: {

--- a/src/state/reducers/Playlist.ts
+++ b/src/state/reducers/Playlist.ts
@@ -310,12 +310,12 @@ export const Playlist = (state = initialState, action: Actions): PlaylistState =
             }
         }
         case SET_RANDOM_NEXT_SONG: {
-            if (state.viewingPlaylist) {
+            if (state.playingPlaylist) {
                 return {
                     ...state,
-                    viewingPlaylist: {
-                        ...state.viewingPlaylist,
-                        playArray: [...state.viewingPlaylist.playArray, ...action.payload]
+                    playingPlaylist: {
+                        ...state.playingPlaylist,
+                        playArray: [...state.playingPlaylist.playArray, ...action.payload]
                     }
                 }
             } else {


### PR DESCRIPTION
# Problem

We have had a couple issues in the app, primarily the following:
1. App randomization would pause after every song
2. App randomization was viewing the playlist from a non-updated state and would crash upon going past the initial batch of song randomization
3. ScrollTo was not scrolling to properly

Song searching is also a useful feature, especially for those with large libraries

# Solution

## Searching and Fixes

Initial search functionality was added into the home screen's artist list and navigation.  With the search box in the navigation headers, this will make it easy to apply the feature on other screens in a repeatable manner.

When the app is in randomization mode, it will now check if the track player is playing, and if not, will trigger play.
When the app is again in randomization mode, the add songs flows will now correctly add songs to the playingPlaylist's play array.
When the app enters playback, it will set the playback screen's currentTrack to the last played, as well as set the last playing track to zero when setting a playlist to play

### Testing How-To

Describe steps to test the changes


## Further Code Changes

Additionally added some betterment to the prettier things and increased the touchable area of the song progress slider

